### PR TITLE
Move tests to unit test package

### DIFF
--- a/MBINCompiler.sln
+++ b/MBINCompiler.sln
@@ -1,9 +1,9 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 14
-VisualStudioVersion = 14.0.25420.1
-MinimumVisualStudioVersion = 10.0.40219.1
+# Visual Studio 2012
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MBINCompiler", "MBINCompiler\MBINCompiler.csproj", "{CE736EF9-7BE9-4FF0-9551-78F0071AA373}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MBINCompilerTests", "MBINCompilerTests\MBINCompilerTests.csproj", "{836B3A35-C1EA-47C8-B3AB-59C0E2E0C763}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -15,6 +15,10 @@ Global
 		{CE736EF9-7BE9-4FF0-9551-78F0071AA373}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{CE736EF9-7BE9-4FF0-9551-78F0071AA373}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{CE736EF9-7BE9-4FF0-9551-78F0071AA373}.Release|Any CPU.Build.0 = Release|Any CPU
+		{836B3A35-C1EA-47C8-B3AB-59C0E2E0C763}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{836B3A35-C1EA-47C8-B3AB-59C0E2E0C763}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{836B3A35-C1EA-47C8-B3AB-59C0E2E0C763}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{836B3A35-C1EA-47C8-B3AB-59C0E2E0C763}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/MBINCompiler/MBINFile.cs
+++ b/MBINCompiler/MBINFile.cs
@@ -8,7 +8,7 @@ using System.Xml;
 
 namespace MBINCompiler
 {
-    class MBINFile
+    public class MBINFile
     {
         public MBINHeader Header;
         private readonly IO _io;

--- a/MBINCompiler/MBINStructs.cs
+++ b/MBINCompiler/MBINStructs.cs
@@ -74,7 +74,7 @@ namespace MBINCompiler
         }
     }
 
-    class MBINHeader : NMSTemplate
+    public class MBINHeader : NMSTemplate
     {
         public int Magic;
         public int Unknown4;

--- a/MBINCompiler/Program.cs
+++ b/MBINCompiler/Program.cs
@@ -24,44 +24,6 @@ namespace MBINCompiler
         // todo: align based on offset of the struct (not offset of the reader!)
         static void Main(string[] args)
         {
-            //List<string> types = new List<string>();
-            //ScanMBINs("C:\\NMS\\", ref types);
-            //File.WriteAllLines("C:\\NMS\\mbins.txt", types.ToArray());
-
-            var tests = new string[] // all of these should decompile fine
-            {
-                @"C:\NMS\METADATA\UI\HUD\SHIPHUD.MBIN", 
-                @"C:\NMS\METADATA\ENTITLEMENTS\GCENTITLEMENTREWARDTABLE.MBIN",
-                @"C:\NMS\SCENES\DEMOS\PS4TEST\MAINSETTINGSPS4TEST.MBIN",
-                @"C:\NMS\METADATA\REALITY\TABLES\NMS_REALITY_GCTECHNOLOGYTABLE.MBIN",
-                @"C:\NMS\METADATA\SIMULATION\SOLARSYSTEM\WEATHER\CLEARWEATHER.MBIN",
-                @"C:\NMS\METADATA\SIMULATION\SOLARSYSTEM\WEATHER\SKYSETTINGS\DAYSKYCOLOURS.MBIN",
-                @"C:\NMS\LANGUAGE\NMS_LOC1_ENGLISH.MBIN",
-                @"C:\NMS\METADATA\REALITY\TABLES\NMS_DIALOG_GCALIENSPEECHTABLE.MBIN",
-                @"C:\NMS\METADATA\REALITY\TABLES\NMS_DIALOG_GCALIENPUZZLETABLE.MBIN"
-            };
-
-            var penaltyBox = new string[]
-            {
-            };
-
-            foreach(var test in tests)
-            {
-                var file2 = new MBINFile(test);
-                file2.Load();
-                var wew = file2.SerializeToXML();
-                wew = wew;
-            }
-
-            /*
-            foreach (var test in penaltyBox)
-            {
-                var file2 = new MBINFile(test);
-                file2.Load();
-                var wew = file2.SerializeToXML();
-                wew = wew;
-            }*/
-
             if (args.Length < 1)
             {
                 Console.WriteLine("Usage: MBINCompiler [InputPath]");
@@ -71,6 +33,7 @@ namespace MBINCompiler
             }
 
             var input = args[0];
+
             if(Path.GetExtension(input).ToLower() != ".mbin")
             {
                 Console.WriteLine("Unsupported input file extension, only .mbin is currently supported, exiting...");

--- a/MBINCompilerTests/MBINCompilerTests.csproj
+++ b/MBINCompilerTests/MBINCompilerTests.csproj
@@ -1,0 +1,93 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{836B3A35-C1EA-47C8-B3AB-59C0E2E0C763}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>MBINCompilerTests</RootNamespace>
+    <AssemblyName>MBINCompilerTests</AssemblyName>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\$(VisualStudioVersion)\UITestExtensionPackages</ReferencePath>
+    <IsCodedUITest>False</IsCodedUITest>
+    <TestProjectType>UnitTest</TestProjectType>
+    <TargetFrameworkProfile />
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup>
+    <StartupObject />
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+  </ItemGroup>
+  <Choose>
+    <When Condition="('$(VisualStudioVersion)' == '10.0' or '$(VisualStudioVersion)' == '') and '$(TargetFrameworkVersion)' == 'v3.5'">
+      <ItemGroup>
+        <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework, Version=10.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
+      </ItemGroup>
+    </When>
+    <Otherwise>
+      <ItemGroup>
+        <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework" />
+      </ItemGroup>
+    </Otherwise>
+  </Choose>
+  <ItemGroup>
+    <Compile Include="UnitTests.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\MBINCompiler\MBINCompiler.csproj">
+      <Project>{ce736ef9-7be9-4ff0-9551-78f0071aa373}</Project>
+      <Name>MBINCompiler</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Choose>
+    <When Condition="'$(VisualStudioVersion)' == '10.0' And '$(IsCodedUITest)' == 'True'">
+      <ItemGroup>
+        <Reference Include="Microsoft.VisualStudio.QualityTools.CodedUITestFramework, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+          <Private>False</Private>
+        </Reference>
+        <Reference Include="Microsoft.VisualStudio.TestTools.UITest.Common, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+          <Private>False</Private>
+        </Reference>
+        <Reference Include="Microsoft.VisualStudio.TestTools.UITest.Extension, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+          <Private>False</Private>
+        </Reference>
+        <Reference Include="Microsoft.VisualStudio.TestTools.UITesting, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+          <Private>False</Private>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Import Project="$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets" Condition="Exists('$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets')" />
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/MBINCompilerTests/Properties/AssemblyInfo.cs
+++ b/MBINCompilerTests/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("MBINCompilerTests")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("MBINCompilerTests")]
+[assembly: AssemblyCopyright("Copyright ©  2016")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("9e8cca0e-97ea-4b30-9472-f15167005c14")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/MBINCompilerTests/UnitTests.cs
+++ b/MBINCompilerTests/UnitTests.cs
@@ -1,31 +1,35 @@
 ﻿using System;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using MBINCompiler;
+using System.IO;
 
 namespace MBINCompilerTests
 {
     [TestClass]
     public class UnitTests
     {
+        String baseDir = "C:/NMS";
+
         [TestMethod]
         public void should_successfully_decompile()
         {
             var tests = new string[] // all of these should decompile fine
             {
-                @"C:\NMS\METADATA\UI\HUD\SHIPHUD.MBIN", 
-                @"C:\NMS\METADATA\ENTITLEMENTS\GCENTITLEMENTREWARDTABLE.MBIN",
-                @"C:\NMS\SCENES\DEMOS\PS4TEST\MAINSETTINGSPS4TEST.MBIN",
-                @"C:\NMS\METADATA\REALITY\TABLES\NMS_REALITY_GCTECHNOLOGYTABLE.MBIN",
-                @"C:\NMS\METADATA\SIMULATION\SOLARSYSTEM\WEATHER\CLEARWEATHER.MBIN",
-                @"C:\NMS\METADATA\SIMULATION\SOLARSYSTEM\WEATHER\SKYSETTINGS\DAYSKYCOLOURS.MBIN",
-                @"C:\NMS\LANGUAGE\NMS_LOC1_ENGLISH.MBIN",
-                @"C:\NMS\METADATA\REALITY\TABLES\NMS_DIALOG_GCALIENSPEECHTABLE.MBIN",
-                @"C:\NMS\METADATA\REALITY\TABLES\NMS_DIALOG_GCALIENPUZZLETABLE.MBIN"
+                "METADATA/UI/HUD/SHIPHUD.MBIN", 
+                "METADATA/ENTITLEMENTS/GCENTITLEMENTREWARDTABLE.MBIN",
+                "SCENES/DEMOS/PS4TEST/MAINSETTINGSPS4TEST.MBIN",
+                "METADATA/REALITY/TABLES/NMS_REALITY_GCTECHNOLOGYTABLE.MBIN",
+                "METADATA/SIMULATION/SOLARSYSTEM/WEATHER/CLEARWEATHER.MBIN",
+                "METADATA/SIMULATION/SOLARSYSTEM/WEATHER/SKYSETTINGS/DAYSKYCOLOURS.MBIN",
+                "LANGUAGE/NMS_LOC1_ENGLISH.MBIN",
+                "METADATA/REALITY/TABLES/NMS_DIALOG_GCALIENSPEECHTABLE.MBIN",
+                "METADATA/REALITY/TABLES/NMS_DIALOG_GCALIENPUZZLETABLE.MBIN"
             };
 
             foreach (var test in tests)
             {
-                var file = new MBINFile(test);
+                String fullPath = Path.Combine(baseDir, test);
+                var file = new MBINFile(fullPath);
                 file.Load();
                 Assert.IsNotNull(file.SerializeToXML(), test + " serialization was null");
             }

--- a/MBINCompilerTests/UnitTests.cs
+++ b/MBINCompilerTests/UnitTests.cs
@@ -25,9 +25,9 @@ namespace MBINCompilerTests
 
             foreach (var test in tests)
             {
-                var file2 = new MBINFile(test);
-                file2.Load();
-                var wew = file2.SerializeToXML();
+                var file = new MBINFile(test);
+                file.Load();
+                Assert.IsNotNull(file.SerializeToXML(), test + " serialization was null");
             }
         }
     }

--- a/MBINCompilerTests/UnitTests.cs
+++ b/MBINCompilerTests/UnitTests.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using MBINCompiler;
+
+namespace MBINCompilerTests
+{
+    [TestClass]
+    public class UnitTests
+    {
+        [TestMethod]
+        public void should_successfully_decompile()
+        {
+            var tests = new string[] // all of these should decompile fine
+            {
+                @"C:\NMS\METADATA\UI\HUD\SHIPHUD.MBIN", 
+                @"C:\NMS\METADATA\ENTITLEMENTS\GCENTITLEMENTREWARDTABLE.MBIN",
+                @"C:\NMS\SCENES\DEMOS\PS4TEST\MAINSETTINGSPS4TEST.MBIN",
+                @"C:\NMS\METADATA\REALITY\TABLES\NMS_REALITY_GCTECHNOLOGYTABLE.MBIN",
+                @"C:\NMS\METADATA\SIMULATION\SOLARSYSTEM\WEATHER\CLEARWEATHER.MBIN",
+                @"C:\NMS\METADATA\SIMULATION\SOLARSYSTEM\WEATHER\SKYSETTINGS\DAYSKYCOLOURS.MBIN",
+                @"C:\NMS\LANGUAGE\NMS_LOC1_ENGLISH.MBIN",
+                @"C:\NMS\METADATA\REALITY\TABLES\NMS_DIALOG_GCALIENSPEECHTABLE.MBIN",
+                @"C:\NMS\METADATA\REALITY\TABLES\NMS_DIALOG_GCALIENPUZZLETABLE.MBIN"
+            };
+
+            foreach (var test in tests)
+            {
+                var file2 = new MBINFile(test);
+                file2.Load();
+                var wew = file2.SerializeToXML();
+            }
+        }
+    }
+}


### PR DESCRIPTION
Just a development support change. I've moved the tests to their own package so they can be run independently, have room to expand and can integrate with Visual Studio's unit test framework.

You can run the test easily by right clicking the `should_successfully_decompile()` method, then _Run Tests_

- Removed tests from `Program.cs`
- Added new package `MBINCompilerTests`
- Made the NMS base directory a parameter (till I think of a better way to have a user-specific param)
- Made `MBINFile` and `MBINHeader` public (required for test)

_Note:_ I'm using Visual Studio Ultimate 2012. I'm not sure if there will be compatibility issues with our versions or if your version doesn't support the unit test structure. Might be best to pull my fork yourself and see if it works (test branch).