### PR TITLE
Fix xml file encoding

### DIFF
--- a/MBINCompiler/Models/NMSTemplate.cs
+++ b/MBINCompiler/Models/NMSTemplate.cs
@@ -233,7 +233,8 @@ namespace MBINCompiler.Models
 
             var xmlSettings = new XmlWriterSettings();
             xmlSettings.Indent = true;
-            using (var stringWriter = new StringWriter())
+            xmlSettings.Encoding = Encoding.UTF8;
+            using (var stringWriter = new EncodedStringWriter(Encoding.UTF8))
             using (var xmlTextWriter = XmlWriter.Create(stringWriter, xmlSettings))
             {
                 xmlDoc.WriteTo(xmlTextWriter);
@@ -304,6 +305,16 @@ namespace MBINCompiler.Models
             }
 
             return el;
+        }
+
+        private sealed class EncodedStringWriter : StringWriter
+        {
+            public EncodedStringWriter(Encoding encoding)
+            {
+                Encoding = encoding;
+            }
+
+            public override Encoding Encoding { get; }
         }
     }
 }


### PR DESCRIPTION
The exml was declared as UTF-16 while it had UTF-8 content (Some text editors noticed that and warned about it).
Now both the encoding-attribute and content will be UTF-8.

~~Don't merge yet. Fixing an invalid whitespace I accidentally added.~~