### PR TITLE
Refactor XML serialization

### DIFF
--- a/MBINCompiler/EXmlFile.cs
+++ b/MBINCompiler/EXmlFile.cs
@@ -1,4 +1,5 @@
 ﻿using System.IO;
+using System.Text;
 using System.Xml;
 using System.Xml.Serialization;
 using MBINCompiler.Models;
@@ -8,16 +9,44 @@ namespace MBINCompiler
     internal static class EXmlFile
     {
         private static readonly XmlSerializer Serializer = new XmlSerializer(typeof(EXmlData));
-
+        private static readonly XmlSerializerNamespaces Namespaces = new XmlSerializerNamespaces(new[] { new XmlQualifiedName("", "") });
+        
         public static NMSTemplate ReadTemplate(string filePath)
         {
             using (var input = File.OpenRead(filePath))
             using (var reader = XmlReader.Create(input))
             {
                 EXmlData root = (EXmlData)Serializer.Deserialize(reader);
-                NMSTemplate rootTemplate = NMSTemplate.DeserializeXml(root);
+                NMSTemplate rootTemplate = NMSTemplate.DeserializeEXml(root);
                 return rootTemplate;
             }
+        }
+
+        public static string WriteTemplate(NMSTemplate template)
+        {
+            var xmlSettings = new XmlWriterSettings
+            {
+                Indent = true,
+                Encoding = Encoding.UTF8
+            };
+            using (var stringWriter = new EncodedStringWriter(Encoding.UTF8))
+            using (var xmlTextWriter = XmlWriter.Create(stringWriter, xmlSettings))
+            {
+                EXmlData data = template.SerializeEXml();
+                Serializer.Serialize(xmlTextWriter, data, Namespaces);
+                xmlTextWriter.Flush();
+                return stringWriter.GetStringBuilder().ToString();
+            }
+        }
+
+        private sealed class EncodedStringWriter : StringWriter
+        {
+            public EncodedStringWriter(Encoding encoding)
+            {
+                Encoding = encoding;
+            }
+
+            public override Encoding Encoding { get; }
         }
     }
 }

--- a/MBINCompiler/MBINCompiler.csproj
+++ b/MBINCompiler/MBINCompiler.csproj
@@ -46,6 +46,7 @@
     <Compile Include="IO.cs" />
     <Compile Include="MBINFile.cs" />
     <Compile Include="EXmlFile.cs" />
+    <Compile Include="Models\EXmlBase.cs" />
     <Compile Include="Models\EXmlData.cs" />
     <Compile Include="Models\EXmlProperty.cs" />
     <Compile Include="Models\MBINHeader.cs" />

--- a/MBINCompiler/Models/EXmlBase.cs
+++ b/MBINCompiler/Models/EXmlBase.cs
@@ -1,0 +1,22 @@
+﻿using System.Collections.Generic;
+using System.Xml.Serialization;
+
+namespace MBINCompiler.Models
+{
+    [XmlInclude(typeof(EXmlData))]
+    [XmlInclude(typeof(EXmlProperty))]
+    public abstract class EXmlBase
+    {
+        protected EXmlBase()
+        {
+            Elements = new List<EXmlBase>();
+        }
+
+        [XmlAttribute("name")]
+        public string Name { get; set; }
+
+        [XmlElement(typeof(EXmlData), ElementName = "Data")]
+        [XmlElement(typeof(EXmlProperty), ElementName = "Property")]
+        public List<EXmlBase> Elements { get; set; }
+    }
+}

--- a/MBINCompiler/Models/EXmlData.cs
+++ b/MBINCompiler/Models/EXmlData.cs
@@ -1,21 +1,11 @@
-﻿using System.Collections.Generic;
-using System.Xml.Serialization;
+﻿using System.Xml.Serialization;
 
 namespace MBINCompiler.Models
 {
     [XmlType("Data")]
-    public class EXmlData
+    public class EXmlData : EXmlBase
     {
         [XmlAttribute("template")]
         public string Template { get; set; }
-
-        [XmlAttribute("name")]
-        public string Name { get; set; }
-
-        [XmlElement("Property")]
-        public List<EXmlProperty> Properties { get; set; }
-
-        [XmlElement("Data")]
-        public List<EXmlData> Data { get; set; }
     }
 }

--- a/MBINCompiler/Models/EXmlProperty.cs
+++ b/MBINCompiler/Models/EXmlProperty.cs
@@ -1,18 +1,12 @@
-﻿using System.Collections.Generic;
-using System.Xml.Serialization;
+﻿using System.Xml.Serialization;
 
 namespace MBINCompiler.Models
 {
-    [XmlType("Property")]
-    public class EXmlProperty
-    {
-        [XmlAttribute("name")]
-        public string Name { get; set; }
 
+    [XmlType("Property")]
+    public class EXmlProperty : EXmlBase
+    {
         [XmlAttribute("value")]
         public string Value { get; set; }
-
-        [XmlElement("Data")]
-        public List<EXmlData> Data { get; set; }
     }
 }

--- a/MBINCompiler/Models/NMSTemplate.cs
+++ b/MBINCompiler/Models/NMSTemplate.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Linq;
 using System.Collections;
-using System.Xml;
 using System.IO;
 using System.Text;
 using System.Collections.Generic;
@@ -218,43 +217,22 @@ namespace MBINCompiler.Models
 
             return list;
         }
-
-        public string SerializeToXml()
+        
+        public EXmlData SerializeEXml()
         {
-            var xmlDoc = new XmlDocument();
-            var el = AppendToXml(null, xmlDoc);
-
-            var xmlSettings = new XmlWriterSettings();
-            xmlSettings.Indent = true;
-            xmlSettings.Encoding = Encoding.UTF8;
-            using (var stringWriter = new EncodedStringWriter(Encoding.UTF8))
-            using (var xmlTextWriter = XmlWriter.Create(stringWriter, xmlSettings))
+            Type type = GetType();
+            EXmlData xmlData = new EXmlData
             {
-                xmlDoc.WriteTo(xmlTextWriter);
-                xmlTextWriter.Flush();
-                return stringWriter.GetStringBuilder().ToString();
-            }
-        }
+                Template = type.Name
+            };
 
-        public XmlElement AppendToXml(XmlElement parentElement, XmlDocument document)
-        {
-            XmlElement el = null;
-            if (parentElement != null)
-                el = (XmlElement)parentElement.AppendChild(document.CreateElement("Data"));
-            else
-                el = (XmlElement)document.AppendChild(document.CreateElement("Data"));
-
-            var type = GetType();
-            el.SetAttribute("template", type.Name);
-
-            var fields = type.GetFields();
-            foreach (var field in fields)
+            foreach (var field in type.GetFields())
             {
                 if (field.Name.StartsWith("Padding"))
                     continue;
                 var fieldName = field.Name;
                 var fieldType = field.FieldType.Name;
-
+                
                 switch (fieldType)
                 {
                     case "String":
@@ -262,8 +240,6 @@ namespace MBINCompiler.Models
                     case "Boolean":
                     case "Int16":
                     case "Int32":
-                        var prop = (XmlElement)el.AppendChild(document.CreateElement("Property"));
-                        prop.SetAttribute("name", fieldName);
                         var value = field.GetValue(this).ToString();
                         var valuesMethod = type.GetMethod(field.Name + "Values"); // if we have an "xxxValues()" method in the struct, use that to get the value name
                         if (valuesMethod != null)
@@ -271,45 +247,61 @@ namespace MBINCompiler.Models
                             string[] values = (string[])valuesMethod.Invoke(this, null);
                             value = values[(int)field.GetValue(this)];
                         }
-                        prop.SetAttribute("value", value);
+
+                        xmlData.Elements.Add(new EXmlProperty
+                        {
+                            Name = fieldName,
+                            Value = value
+                        });
                         break;
 
                     case "Byte[]":
                         byte[] bytes = (byte[])field.GetValue(this);
                         string base64Value = bytes == null ? null : Convert.ToBase64String(bytes);
-                        var prop2 = (XmlElement)el.AppendChild(document.CreateElement("Property"));
-                        prop2.SetAttribute("name", fieldName);
-                        prop2.SetAttribute("value", base64Value);
+                        
+                        xmlData.Elements.Add(new EXmlProperty
+                        {
+                            Name = fieldName,
+                            Value = base64Value
+                        });
                         break;
                     case "List`1":
-                        var prop3 = (XmlElement)el.AppendChild(document.CreateElement("Property"));
-                        prop3.SetAttribute("name", fieldName);
+                        EXmlProperty listProperty = new EXmlProperty
+                        {
+                            Name = fieldName
+                        };
 
                         IList templates = (IList)field.GetValue(this);
-                        foreach (var template in templates)
-                            ((NMSTemplate)template).AppendToXml(prop3, document);
+                        foreach (var template in templates.Cast<NMSTemplate>())
+                        {
+                            listProperty.Elements.Add(template.SerializeEXml());
+                        }
 
+                        xmlData.Elements.Add(listProperty);
                         break;
-
                     default:
                         if (field.FieldType.BaseType.Name == "NMSTemplate")
                         {
                             NMSTemplate template = (NMSTemplate)field.GetValue(this);
-                            var element = template.AppendToXml(el, document);
-                            element.SetAttribute("name", fieldName);
+
+                            EXmlData templateXmlData = template.SerializeEXml();
+                            templateXmlData.Name = fieldName;
+
+                            xmlData.Elements.Add(templateXmlData);
                         }
+
                         break;
                 }
             }
 
-            return el;
+            return xmlData;
         }
 
-        public static NMSTemplate DeserializeXml(EXmlData xmlData)
+        public static NMSTemplate DeserializeEXml(EXmlData xmlData)
         {
             NMSTemplate template = TemplateFromName(xmlData.Template);
             Type templateType = template.GetType();
-            foreach (var xmlProperty in xmlData.Properties)
+            foreach (var xmlProperty in xmlData.Elements.OfType<EXmlProperty>())
             {
                 FieldInfo field = templateType.GetField(xmlProperty.Name);
                 Type fieldType = field.FieldType;
@@ -350,9 +342,9 @@ namespace MBINCompiler.Models
                         Type elementType = fieldType.GetGenericArguments()[0];
                         Type listType = typeof(List<>).MakeGenericType(elementType);
                         IList list = (IList)Activator.CreateInstance(listType);
-                        foreach (EXmlData innerXmlData in xmlProperty.Data)
+                        foreach (EXmlData innerXmlData in xmlProperty.Elements.OfType<EXmlData>())
                         {
-                            NMSTemplate element = DeserializeXml(innerXmlData);
+                            NMSTemplate element = DeserializeEXml(innerXmlData);
                             list.Add(element);
                         }
 
@@ -366,24 +358,14 @@ namespace MBINCompiler.Models
                 field.SetValue(template, fieldValue);
             }
 
-            foreach (EXmlData innerXmlData in xmlData.Data)
+            foreach (EXmlData innerXmlData in xmlData.Elements.OfType<EXmlData>())
             {
                 FieldInfo field = templateType.GetField(innerXmlData.Name);
-                NMSTemplate innerTemplate = DeserializeXml(innerXmlData);
+                NMSTemplate innerTemplate = DeserializeEXml(innerXmlData);
                 field.SetValue(template, innerTemplate);
             }
 
             return template;
-        }
-
-        private sealed class EncodedStringWriter : StringWriter
-        {
-            public EncodedStringWriter(Encoding encoding)
-            {
-                Encoding = encoding;
-            }
-
-            public override Encoding Encoding { get; }
         }
     }
 }

--- a/MBINCompiler/Program.cs
+++ b/MBINCompiler/Program.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
+using MBINCompiler.Models;
 
 namespace MBINCompiler
 {
@@ -17,7 +18,7 @@ namespace MBINCompiler
             foreach (var folder in Directory.GetDirectories(path))
                 ScanMBINs(folder, ref types);
         }
-        
+
         static void Main(string[] args)
         {
             if (args.Length < 1)
@@ -37,7 +38,7 @@ namespace MBINCompiler
             }
 
             var output = Path.ChangeExtension(input, ".exml"); // emoose XML, because there's no way this XML format is compatible with MXML
-            if(File.Exists(output))
+            if (File.Exists(output))
             {
                 Console.WriteLine("Output file \"" + output + "\" already exists, exiting...");
                 return;
@@ -47,15 +48,15 @@ namespace MBINCompiler
             var file = new MBINFile(input);
             file.Load();
 
-            var data = file.GetData();
+            NMSTemplate data = file.GetData();
             if(data == null)
             {
                 Console.WriteLine("Failed to deserialize template \"" + file.Header.GetXMLTemplateName() + "\", has the structure been mapped yet?");
                 return;
             }
-
-            var xmlString = data.SerializeToXml();
-            if(string.IsNullOrEmpty(xmlString))
+            
+            var xmlString = EXmlFile.WriteTemplate(data);
+            if (string.IsNullOrEmpty(xmlString))
             {
                 Console.WriteLine("Error serializing template \"" + file.Header.GetXMLTemplateName() + "\" to XML!");
                 return;

--- a/MBINCompilerTests/UnitTests.cs
+++ b/MBINCompilerTests/UnitTests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using MBINCompiler;
 using MBINCompiler.Models.Structs;
@@ -21,10 +22,11 @@ namespace MBINCompilerTests
 
             var data = file.GetData();
             Assert.IsNotNull(data, testFile1 + " deserialized data was null");
-            Assert.IsNotNull(data.SerializeToXml(), testFile1 + " xml serialization was null");
-            Assert.IsInstanceOfType(data, typeof(MBINCompilerTestTemplate), testFile1 + " template isn't of type MBINCompilerTestTemplate!");
+            Assert.IsNotNull(data.SerializeEXml(), testFile1 + " xml serialization was null");
+            Assert.IsInstanceOfType(data, typeof(MBINCompilerTestTemplate),
+                testFile1 + " template isn't of type MBINCompilerTestTemplate!");
 
-            MBINCompilerTestTemplate test = (MBINCompilerTestTemplate)data;
+            MBINCompilerTestTemplate test = (MBINCompilerTestTemplate) data;
             Assert.AreEqual(test.TestBoolTrue, true);
             Assert.AreEqual(test.TestBoolFalse, false);
             Assert.AreEqual(test.TestBool3, true);
@@ -41,10 +43,10 @@ namespace MBINCompilerTests
             var expectedDynamicString = "NoWayToControlItIt'sTotallyDynamicWheneverYou'reAround";
             Assert.AreEqual(test.TestDynamicString.Value, expectedDynamicString);
 
-            string[] expectedStrings = new[] { "FirstEntry", "SecondEntry", "ThirdEntry" };
+            string[] expectedStrings = new[] {"FirstEntry", "SecondEntry", "ThirdEntry"};
             Assert.AreEqual(test.Test0x80ByteStringList.Count, expectedStrings.Length);
 
-            for(int i = 0; i < expectedStrings.Length; i++)
+            for (int i = 0; i < expectedStrings.Length; i++)
                 Assert.AreEqual(test.Test0x80ByteStringList[i].Value, expectedStrings[i]);
         }
 
@@ -961,10 +963,10 @@ namespace MBINCompilerTests
                 var file = new MBINFile(fullPath);
                 file.Load();
 
-                System.Diagnostics.Debug.WriteLine("testing " + test);
+                Debug.WriteLine("testing " + test);
                 var data = file.GetData();
                 Assert.IsNotNull(data, test + " deserialized data was null");
-                Assert.IsNotNull(data.SerializeToXml(), test + " xml serialization was null");
+                Assert.IsNotNull(data.SerializeEXml(), test + " xml serialization was null");
             }
         }
     }


### PR DESCRIPTION
Use custom XML classes and the XmlSerializer class instead of appending elements and attributes to an XmlDocument manually.
The resulting XML file will be equivalent (the XML element order is the same, but the XML attributes are now ordered alphabetically.)