### PR TITLE
Fix file extension check in Turkish locale

### DIFF
--- a/MBINCompiler/Program.cs
+++ b/MBINCompiler/Program.cs
@@ -92,10 +92,10 @@ namespace MBINCompiler
 
             var input = args[0];
             var output = args.Length > 1 ? args[1] : String.Empty;
-            var inputExtension = Path.GetExtension(input).ToLower();
-            if (inputExtension == ".mbin")
+            var inputExtension = Path.GetExtension(input) ?? String.Empty;
+            if (inputExtension.Equals(".mbin", StringComparison.OrdinalIgnoreCase))
                 DecompileFile(input, output);
-            else if (inputExtension == ".exml")
+            else if (inputExtension.Equals(".exml", StringComparison.OrdinalIgnoreCase)) 
                 CompileFile(input, output);
             else
             {


### PR DESCRIPTION
ToLower/ToUpper can't be used to compare strings (which contains the letter **i**) in a case insensitive way in the Turkish locale.

See this blog post :
https://blog.codinghorror.com/whats-wrong-with-turkey/

Fixes  #45