### PR TITLE
NMSTemplate.ReadXmlDataFromString & visibility modifier

### DIFF
--- a/MBINCompiler/EXmlFile.cs
+++ b/MBINCompiler/EXmlFile.cs
@@ -37,6 +37,12 @@ namespace MBINCompiler
             return rootTemplate;
         }
 
+        public static EXmlData ReadExmlDataFromString(string xml)
+        {
+            using (var reader = new StringReader(xml))
+            using (var xmlReader = XmlReader.Create(reader))
+                return (EXmlData)Serializer.Deserialize(xmlReader);
+        }
 
         public static string WriteTemplate(NMSTemplate template)
         {

--- a/MBINCompiler/Models/Structs/GcBootLogoData.cs
+++ b/MBINCompiler/Models/Structs/GcBootLogoData.cs
@@ -2,7 +2,7 @@
 
 namespace MBINCompiler.Models.Structs
 {
-    class GcBootLogoData : NMSTemplate
+    public class GcBootLogoData : NMSTemplate
     {
         [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 0x100)]
         public string Texture1;

--- a/MBINCompiler/Models/Structs/GcWaterGlobals.cs
+++ b/MBINCompiler/Models/Structs/GcWaterGlobals.cs
@@ -1,6 +1,6 @@
 ﻿namespace MBINCompiler.Models.Structs
 {
-    class GcWaterGlobals : NMSTemplate
+    public class GcWaterGlobals : NMSTemplate
     {
         public bool Unknown0; // enable/disable water perhaps?
     }


### PR DESCRIPTION
Added `ReadXmlDataFromString(string)` to `NMSTemplate`.

Also hanged visibility modifier of `GcBootLogoData` & `GcWaterGlobals` to public.

Both changes make it easier to use MBINCompiler as reference.