### PR TITLE
Change GcSolarGenerationGlobals

### DIFF
--- a/MBINCompiler/Models/Structs/Unfinished/GcSolarGenerationGlobals.cs
+++ b/MBINCompiler/Models/Structs/Unfinished/GcSolarGenerationGlobals.cs
@@ -6,101 +6,104 @@ using System.Threading.Tasks;
 
 namespace MBINCompiler.Models.Structs
 {
-
     public class GcSolarGenerationGlobals : NMSTemplate
     {
-        public uint unk60;
-        public float unk64;
-        public float unk68;
-        public float unk6C;
-        public float unk70;
-        public float unk74;
-        public float unk78;
-        public float unk7C;
+        public bool Unknown0;
+        [NMS(Size = 0xF)]
+        public byte[] Unknown1;
+
+        public float Unknown10;
+        public float Unknown14;
+        public float Unknown18; // unused? 
+        public float Unknown1C; // unused? 
+
         public float minPlanetDistance;
         public float maxPlanetDistance;
-        public float unk88;
-        public float unk8c;
-        public uint unk90;
-        public float unk94;
-        public float unk98;
-        public float unk9C;
-        public float unkA0;
-        public float unkA4;
-        public float unkA8;
-        public float unkAC;
-        public float unkB0;
-        public uint unkB4;
-        public uint unkB8;
-        public float unkBC;
-        public uint unkC0;
-        public uint unkC4;
-        public float unkC8;
-        public float unkCC;
-        public float unkD0;
-        public uint unkD4;
-        public float unkD8;
-        public float unkDC;
-        public uint unkE0;
-        public float unkE4;
-        public float unkE8;
-        public float unkEC;
-        public float unkF0;
-        public float unkF4;
-        public float unkF8;
-        public float unkFC;
-        public float unk100;
-        public float unk104;
-        public float unk108;
-        public float unk10C;
-        public float unk110;
-        public float unk114;
-        public float unk118;
+        public float Unknown28; // unused?   // changed bool to float
+        public int Unknown2c; // unused? non-float?
+
+        public float Unknown30; // changed bool to float
+        public float Unknown34; // unused?
+        public float Unknown38; // unused?
+        public float Unknown3C; // qword?
+
+        public float Unknown40; // unused?
+        public float Unknown44;
+        public float Unknown48;
+        public float Unknown4C;
+
+        public float Unknown50;
+        public int Unknown54;
+        public int Unknown58;
+        public float Unknown5C;
+
+        public int Unknown60;
+        public int Unknown64;
+        public float Unknown68;
+        public float Unknown6C;
+
+        public float Unknown70;
+        public uint Unknown74; // changed bool to uint
+        public float Unknown78;
+        public float Unknown7C;
+
+        public int Unknown80;
+        public float Unknown84; // unused?
+        public float Unknown88; // unused?
+        public float Unknown8C;
+
+        public float Unknown90;
+        public float Unknown94;
+        public float Unknown98;
+        public float Unknown9C;
+
+        public float UnknownA0;
+        public float UnknownA4;
+        public float UnknownA8;
+        public float UnknownAC;
+
+        public float UnknownB0;
+        public float UnknownB4;
+        public float UnknownB8;
         public float UnknownAsteroidSpacing;
+
         public float UnknownAsteroidFadeIn;
-        public float unk124;
-        public uint UnknownAsteroidMinDropAmount;
-        public uint UnknownAsteroidMaxDropAmount;
+        public float UnknownC4;
+        public int UnknownAsteroidMinDropAmount;
+        public int UnknownAsteroidMaxDropAmount;
+
         [NMS(Size = 16)]
         public string UnknownAsteroidDroppedItem;
+
         public float SmallAsteroidScale;
         public float SmallAsteroidSpacing;
         public float SmallAsteroidFadeIn;
-        public float unk14C;
-        public uint SmallAsteroidMinDropAmount;
-        public uint SmallAsteroidMaxDropAmount;
-        [NMS(Size = 16)]
-        public string SmallAsteroidDroppedItem;
-        public float unk168;
-        public float unk16C;
-        public float LargeAsteroidSpacing_maybe;
-        public float unk174;
-        public float LargeAsteroidFadeIn_maybe;
-        public float unk17C;
-        public float unk180;
-        public float unk184;
-        public uint unk188;
-        public float unk18C;
-        public float unk190;
-        public uint unk194;
-        public uint unk198;
-        public uint unk19C;
-        public uint unk1A0;
-        public uint unk1A4;
-        public uint unk1A8;
-        public uint unk1AC;
-        public uint unk1B0;
-        public uint unk1B4;
-        public uint unk1B8;
-        public uint unk1BC;
-        public uint unk1C0;
-        public uint unk1C4;
-        public uint unk1C8;
-        public uint unk1CC;
-        public uint unk1D0;
-        public uint unk1D4;
-        public uint unk1D8;
-        public uint unk1DC;
-    }
+        public float UnknownEC;
 
+        public int SmallAsteroidMinDropAmount;
+        public int SmallAsteroidMaxDropAmount;
+
+        [NMS(Size = 0x10)]
+        public string SmallAsteroidDroppedItem;
+
+        public float Unknown108; // unused?
+        public float Unknown10C; // unused?
+
+        public float LargeAsteroidSpacing_maybe;
+        public float Unknown114;
+        public float LargeAsteroidFadeIn_maybe;
+        public float Unknown11C;
+
+        public float Unknown120; // unused?
+        public float Unknown124; // unused?
+        public int Unknown128;
+        public float Unknown12C;
+
+        public float Unknown130;
+
+        [NMS(Size = 0x6)]
+        public Vector3i Unknown134;
+
+        public int Unknown17C;
+    }
 }

--- a/MBINCompiler/Models/Structs/Unfinished/GcSolarGenerationGlobals.cs
+++ b/MBINCompiler/Models/Structs/Unfinished/GcSolarGenerationGlobals.cs
@@ -6,104 +6,101 @@ using System.Threading.Tasks;
 
 namespace MBINCompiler.Models.Structs
 {
+
     public class GcSolarGenerationGlobals : NMSTemplate
     {
-        public bool Unknown0;
-        [NMS(Size = 0xF)]
-        public byte[] Unknown1;
-
-        public float Unknown10;
-        public float Unknown14;
-        public float Unknown18; // unused?
-        public float Unknown1C; // unused?
-
-        public float Unknown20;
-        public float Unknown24;
-        public bool Unknown28; // unused?
-        public int Unknown2C; // unused? non-float?
-
-        public bool Unknown30;
-        public float Unknown34; // unused?
-        public float Unknown38; // unused?
-        public float Unknown3C; // qword?
-
-        public float Unknown40; // unused?
-        public float Unknown44;
-        public float Unknown48;
-        public float Unknown4C;
-
-        public float Unknown50;
-        public int Unknown54;
-        public int Unknown58;
-        public float Unknown5C;
-
-        public int Unknown60;
-        public int Unknown64;
-        public float Unknown68;
-        public float Unknown6C;
-
-        public float Unknown70;
-        public bool Unknown74;
-        public float Unknown78;
-        public float Unknown7C;
-
-        public int Unknown80;
-        public float Unknown84; // unused?
-        public float Unknown88; // unused?
-        public float Unknown8C;
-
-        public float Unknown90;
-        public float Unknown94;
-        public float Unknown98;
-        public float Unknown9C;
-
-        public float UnknownA0;
-        public float UnknownA4;
-        public float UnknownA8;
-        public float UnknownAC;
-
-        public float UnknownB0;
-        public float UnknownB4;
-        public float UnknownB8;
-        public float UnknownBC;
-
-        public float UnknownC0;
-        public float UnknownC4;
-        public int UnknownC8;
-        public int UnknownCC;
-
-        [NMS(Size = 0x10)]
-        public string UnknownD0; // unused?
-
-        public float UnknownE0;
-        public float UnknownE4;
-        public float UnknownE8;
-        public float UnknownEC;
-
-        public int UnknownF0;
-        public int UnknownF4;
-
-        [NMS(Size = 0x10)]
-        public string UnknownF8;
-
-        public float Unknown108; // unused?
-        public float Unknown10C; // unused?
-
-        public float Unknown110;
-        public float Unknown114;
-        public float Unknown118;
-        public float Unknown11C;
-
-        public float Unknown120; // unused?
-        public float Unknown124; // unused?
-        public int Unknown128;
-        public float Unknown12C;
-
-        public float Unknown130;
-
-        [NMS(Size = 6)]
-        public Vector3i[] Unknown134;
-
-        public int Unknown17C;
+        public uint unk60;
+        public float unk64;
+        public float unk68;
+        public float unk6C;
+        public float unk70;
+        public float unk74;
+        public float unk78;
+        public float unk7C;
+        public float minPlanetDistance;
+        public float maxPlanetDistance;
+        public float unk88;
+        public float unk8c;
+        public uint unk90;
+        public float unk94;
+        public float unk98;
+        public float unk9C;
+        public float unkA0;
+        public float unkA4;
+        public float unkA8;
+        public float unkAC;
+        public float unkB0;
+        public uint unkB4;
+        public uint unkB8;
+        public float unkBC;
+        public uint unkC0;
+        public uint unkC4;
+        public float unkC8;
+        public float unkCC;
+        public float unkD0;
+        public uint unkD4;
+        public float unkD8;
+        public float unkDC;
+        public uint unkE0;
+        public float unkE4;
+        public float unkE8;
+        public float unkEC;
+        public float unkF0;
+        public float unkF4;
+        public float unkF8;
+        public float unkFC;
+        public float unk100;
+        public float unk104;
+        public float unk108;
+        public float unk10C;
+        public float unk110;
+        public float unk114;
+        public float unk118;
+        public float UnknownAsteroidSpacing;
+        public float UnknownAsteroidFadeIn;
+        public float unk124;
+        public uint UnknownAsteroidMinDropAmount;
+        public uint UnknownAsteroidMaxDropAmount;
+        [NMS(Size = 16)]
+        public string UnknownAsteroidDroppedItem;
+        public float SmallAsteroidScale;
+        public float SmallAsteroidSpacing;
+        public float SmallAsteroidFadeIn;
+        public float unk14C;
+        public uint SmallAsteroidMinDropAmount;
+        public uint SmallAsteroidMaxDropAmount;
+        [NMS(Size = 16)]
+        public string SmallAsteroidDroppedItem;
+        public float unk168;
+        public float unk16C;
+        public float LargeAsteroidSpacing_maybe;
+        public float unk174;
+        public float LargeAsteroidFadeIn_maybe;
+        public float unk17C;
+        public float unk180;
+        public float unk184;
+        public uint unk188;
+        public float unk18C;
+        public float unk190;
+        public uint unk194;
+        public uint unk198;
+        public uint unk19C;
+        public uint unk1A0;
+        public uint unk1A4;
+        public uint unk1A8;
+        public uint unk1AC;
+        public uint unk1B0;
+        public uint unk1B4;
+        public uint unk1B8;
+        public uint unk1BC;
+        public uint unk1C0;
+        public uint unk1C4;
+        public uint unk1C8;
+        public uint unk1CC;
+        public uint unk1D0;
+        public uint unk1D4;
+        public uint unk1D8;
+        public uint unk1DC;
     }
+
 }


### PR DESCRIPTION
Changed `GcSolarGenerationGlobals` to a template, that @spAnser created for hex workshop.

This is not by any means complete, but contains some names that he worked out by trial & error. :+1: 