### PR TITLE
Fixed crashing when using no args

### DIFF
--- a/MBINCompiler/Program.cs
+++ b/MBINCompiler/Program.cs
@@ -164,7 +164,7 @@ namespace MBINCompiler
         {
             string input, output;
 
-            if (args[0] == "/?" || args[0] == "/help" || args[0] == "--help" || args[0] == "-h" || args.Length < 1)
+            if (args.Length < 1 || args[0] == "/?" || args[0] == "/help" || args[0] == "--help" || args[0] == "-h")
             {
                 PrintHelp();
                 return;


### PR DESCRIPTION
You should've put the "Length less than 1" test at the beginning of the if statement to short circuit it and not cause a crash when testing the value of `args[0]` later. ¯\\\_(ツ)\_/¯