### PR TITLE
Fixed NMSAttribute useage

### DIFF
--- a/MBINCompiler/Models/NMSAttribute.cs
+++ b/MBINCompiler/Models/NMSAttribute.cs
@@ -1,72 +1,13 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace MBINCompiler.Models
 {
     [AttributeUsage(AttributeTargets.Property | AttributeTargets.Field | AttributeTargets.GenericParameter)]
     public class NMSAttribute : Attribute
     {
-        private int size;
-        public int Size
-        {
-          get
-          {
-              return size;
-          }
-          set
-          {
-              size = value;
-          }
-        }
-
-        private bool ignore;
-        public bool Ignore
-        {
-            get
-            {
-                return ignore;
-            }
-            set
-            {
-                ignore = value;
-            }
-        }
-
-        private object defaultValue;
-        public object DefaultValue
-        {
-            get
-            {
-                return defaultValue;
-            }
-            set
-            {
-                defaultValue = value;
-            }
-        }
-
-        private string[] enumValue;
-        public string[] EnumValue
-        {
-            get
-            {
-                return enumValue;
-            }
-            set
-            {
-                enumValue = value;
-            }
-        }
-
-        public NMSAttribute() 
-        {
-            size = 0;
-            ignore = false;
-            defaultValue = null;
-            enumValue = null;
-        }
+        public int Size { get; set; }
+        public bool Ignore { get; set; }
+        public object DefaultValue { get; set; }
+        public string[] EnumValue { get; set; }
     }
 }

--- a/MBINCompiler/Models/Structs/GcAIShipSpawnData.cs
+++ b/MBINCompiler/Models/Structs/GcAIShipSpawnData.cs
@@ -4,7 +4,7 @@ namespace MBINCompiler.Models.Structs
 {
     public class GcAIShipSpawnData : NMSTemplate
     {
-        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 0x20)]
+        [NMS(Size = 0x20)]
         public string Message;
 
         public TkInputEnum InputEnum;
@@ -12,12 +12,11 @@ namespace MBINCompiler.Models.Structs
         public GcAISpaceshipRoles ShipRole;
         public float MinRange;
         public float Scale;
-        [MarshalAs(UnmanagedType.ByValArray, SizeConst = 4)]
-        [NMSAttribute(Ignore = true)]
+        [NMS(Size = 4, Ignore = true)]
         public byte[] Padding34;
-        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 0x10)]
+        [NMS(Size = 0x10)]
         public string Reward;
-        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 0x20)]
+        [NMS(Size = 0x20)]
         public string RewardMessage;
         public bool AttackFreighter;
         public Vector2f Spread;

--- a/MBINCompiler/Models/Structs/GcAISpaceshipPreloadCacheData.cs
+++ b/MBINCompiler/Models/Structs/GcAISpaceshipPreloadCacheData.cs
@@ -5,12 +5,11 @@ namespace MBINCompiler.Models.Structs
     public class GcAISpaceshipPreloadCacheData : NMSTemplate
     {
         public GcAISpaceshipRoles ShipRole;
-        [MarshalAs(UnmanagedType.ByValArray, SizeConst = 4)]
-        [NMSAttribute(Ignore = true)]
+        [NMS(Size = 4, Ignore = true)]
         public byte[] Padding4;
 
         public GcSeed Seed;
-        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 0x100)]
+        [NMS(Size = 0x100)]
         public string AltId;
     }
 }

--- a/MBINCompiler/Models/Structs/GcAISpaceshipPreloadCacheData.cs
+++ b/MBINCompiler/Models/Structs/GcAISpaceshipPreloadCacheData.cs
@@ -1,6 +1,4 @@
-﻿using System.Runtime.InteropServices;
-
-namespace MBINCompiler.Models.Structs
+﻿namespace MBINCompiler.Models.Structs
 {
     public class GcAISpaceshipPreloadCacheData : NMSTemplate
     {

--- a/MBINCompiler/Models/Structs/GcAISpaceshipPreloadList.cs
+++ b/MBINCompiler/Models/Structs/GcAISpaceshipPreloadList.cs
@@ -6,8 +6,7 @@ namespace MBINCompiler.Models.Structs
     public class GcAISpaceshipPreloadList : NMSTemplate
     {
         public GcRealityCommonFactions Faction;
-        [MarshalAs(UnmanagedType.ByValArray, SizeConst = 4)]
-        [NMSAttribute(Ignore = true)]
+        [NMS(Size = 4, Ignore = true)]
         public byte[] Padding4;
 
         public List<GcAISpaceshipPreloadCacheData> Cache;

--- a/MBINCompiler/Models/Structs/GcAISpaceshipPreloadList.cs
+++ b/MBINCompiler/Models/Structs/GcAISpaceshipPreloadList.cs
@@ -1,5 +1,4 @@
 ﻿using System.Collections.Generic;
-using System.Runtime.InteropServices;
 
 namespace MBINCompiler.Models.Structs
 {

--- a/MBINCompiler/Models/Structs/GcAlienPuzzleEntry.cs
+++ b/MBINCompiler/Models/Structs/GcAlienPuzzleEntry.cs
@@ -1,5 +1,4 @@
 ﻿using System.Collections.Generic;
-using System.Runtime.InteropServices;
 
 namespace MBINCompiler.Models.Structs
 {

--- a/MBINCompiler/Models/Structs/GcAlienPuzzleEntry.cs
+++ b/MBINCompiler/Models/Structs/GcAlienPuzzleEntry.cs
@@ -5,16 +5,16 @@ namespace MBINCompiler.Models.Structs
 {
     public class GcAlienPuzzleEntry : NMSTemplate
     {
-        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 0x10)]
+        [NMS(Size = 0x10)]
         public string Id;
 
         public GcAlienRace AlienRace;
         public GcInteractionType InteractionType;
 
-        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 0x200)]
+        [NMS(Size = 0x200)]
         public string Text;
 
-        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 0x200)]
+        [NMS(Size = 0x200)]
         public string TextAlien;
 
         public bool TranslateAlienText;

--- a/MBINCompiler/Models/Structs/GcAlienPuzzleOption.cs
+++ b/MBINCompiler/Models/Structs/GcAlienPuzzleOption.cs
@@ -1,5 +1,4 @@
 ﻿using System.Collections.Generic;
-using System.Runtime.InteropServices;
 
 namespace MBINCompiler.Models.Structs
 {

--- a/MBINCompiler/Models/Structs/GcAlienPuzzleOption.cs
+++ b/MBINCompiler/Models/Structs/GcAlienPuzzleOption.cs
@@ -5,15 +5,15 @@ namespace MBINCompiler.Models.Structs
 {
     public class GcAlienPuzzleOption : NMSTemplate
     {
-        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 0x20)]
+        [NMS(Size = 0x20)]
         /* 0x000 */
         public string Name;
 
-        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 0x200)]
+        [NMS(Size = 0x200)]
         /* 0x020 */
         public string Text;
 
-        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 0x10)]
+        [NMS(Size = 0x10)]
         /* 0x220 */
         public string Cost;
 
@@ -30,8 +30,7 @@ namespace MBINCompiler.Models.Structs
         /* 0x244 */
         public bool KeepOpen;
 
-        [MarshalAs(UnmanagedType.ByValArray, SizeConst = 3)]
-        [NMSAttribute(Ignore = true)]
+        [NMS(Size = 3, Ignore = true)]
         public byte[] Padding;
     }
 }

--- a/MBINCompiler/Models/Structs/GcAlienSpeechEntry.cs
+++ b/MBINCompiler/Models/Structs/GcAlienSpeechEntry.cs
@@ -4,10 +4,10 @@ namespace MBINCompiler.Models.Structs
 {
     public class GcAlienSpeechEntry : NMSTemplate
     {
-        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 0x10)]
+        [NMS(Size = 0x10)]
         public string Id;
 
-        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 0x20)]
+        [NMS(Size = 0x20)]
         public string Text;
 
         public int WordInteractEffect;

--- a/MBINCompiler/Models/Structs/GcAlienSpeechEntry.cs
+++ b/MBINCompiler/Models/Structs/GcAlienSpeechEntry.cs
@@ -1,6 +1,4 @@
-﻿using System.Runtime.InteropServices;
-
-namespace MBINCompiler.Models.Structs
+﻿namespace MBINCompiler.Models.Structs
 {
     public class GcAlienSpeechEntry : NMSTemplate
     {

--- a/MBINCompiler/Models/Structs/GcAlienSpeechEntry.cs
+++ b/MBINCompiler/Models/Structs/GcAlienSpeechEntry.cs
@@ -19,7 +19,7 @@ namespace MBINCompiler.Models.Structs
 
         public GcAlienRace AlienRace;
         public int Level;
-        [NMSAttribute(Ignore = true)]
+        [NMS(Ignore = true)]
         public int Padding;
     }
 }

--- a/MBINCompiler/Models/Structs/GcBiomeData.cs
+++ b/MBINCompiler/Models/Structs/GcBiomeData.cs
@@ -10,17 +10,17 @@ namespace MBINCompiler.Models.Structs
         public GcMiningSubstanceData MiningSubstance4;
         public GcPlanetWaterData Water;
 
-        [NMSAttribute(Size = 0x80)]
+        [NMS(Size = 0x80)]
         public string DiffuseMap;
-        [NMSAttribute(Size = 0x80)]
+        [NMS(Size = 0x80)]
         public string NormalMap;
 
-        [NMSAttribute(Size = 10)]
+        [NMS(Size = 10)]
         public GcTileTypeOptions[] TileTypes;
 
         public List<GcExternalObjectListOptions> ExternalObjectLists;
 
-        [NMSAttribute(Size = 7, EnumValue = new string[7] { "Clear", "Dust", "Humid", "Snow", "Toxic", "Scorched", "Radioactive" } )]
+        [NMS(Size = 7, EnumValue = new string[7] { "Clear", "Dust", "Humid", "Snow", "Toxic", "Scorched", "Radioactive" } )]
         public NMSBool[] WeatherOptions;
 
         public GcTerrainControls Terrain;

--- a/MBINCompiler/Models/Structs/GcBiomeFileList.cs
+++ b/MBINCompiler/Models/Structs/GcBiomeFileList.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using System.Collections.Generic;
 
 namespace MBINCompiler.Models.Structs
 {

--- a/MBINCompiler/Models/Structs/GcBirdData.cs
+++ b/MBINCompiler/Models/Structs/GcBirdData.cs
@@ -9,7 +9,7 @@ namespace MBINCompiler.Models.Structs
         public float FlapSpeed;
         public float FlapAccel;
 
-        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 0x80)]
+        [NMS(Size = 0x80)]
         public string CircleAttractor;
     }
 }

--- a/MBINCompiler/Models/Structs/GcBirdData.cs
+++ b/MBINCompiler/Models/Structs/GcBirdData.cs
@@ -1,6 +1,4 @@
-﻿using System.Runtime.InteropServices;
-
-namespace MBINCompiler.Models.Structs
+﻿namespace MBINCompiler.Models.Structs
 {
     public class GcBirdData : NMSTemplate
     {

--- a/MBINCompiler/Models/Structs/GcBootLogoData.cs
+++ b/MBINCompiler/Models/Structs/GcBootLogoData.cs
@@ -1,6 +1,4 @@
-﻿using System.Runtime.InteropServices;
-
-namespace MBINCompiler.Models.Structs
+﻿namespace MBINCompiler.Models.Structs
 {
     public class GcBootLogoData : NMSTemplate
     {

--- a/MBINCompiler/Models/Structs/GcBootLogoData.cs
+++ b/MBINCompiler/Models/Structs/GcBootLogoData.cs
@@ -4,13 +4,13 @@ namespace MBINCompiler.Models.Structs
 {
     public class GcBootLogoData : NMSTemplate
     {
-        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 0x100)]
+        [NMS(Size = 0x100)]
         public string Texture1;
-        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 0x100)]
+        [NMS(Size = 0x100)]
         public string Texture2;
-        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 0x100)]
+        [NMS(Size = 0x100)]
         public string Texture3;
-        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 0x100)]
+        [NMS(Size = 0x100)]
         public string Texture4;
 
         public float DisplayTime1;

--- a/MBINCompiler/Models/Structs/GcCostJourneyMilestone.cs
+++ b/MBINCompiler/Models/Structs/GcCostJourneyMilestone.cs
@@ -1,6 +1,4 @@
-﻿using System.Runtime.InteropServices;
-
-namespace MBINCompiler.Models.Structs
+﻿namespace MBINCompiler.Models.Structs
 {
     public class GcCostJourneyMilestone : NMSTemplate
     {

--- a/MBINCompiler/Models/Structs/GcCostJourneyMilestone.cs
+++ b/MBINCompiler/Models/Structs/GcCostJourneyMilestone.cs
@@ -4,7 +4,7 @@ namespace MBINCompiler.Models.Structs
 {
     public class GcCostJourneyMilestone : NMSTemplate
     {
-        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 0x10)]
+        [NMS(Size = 0x10)]
         public string RequiredMilestone;
     }
 }

--- a/MBINCompiler/Models/Structs/GcCostJourneyStatLevel.cs
+++ b/MBINCompiler/Models/Structs/GcCostJourneyStatLevel.cs
@@ -4,7 +4,7 @@ namespace MBINCompiler.Models.Structs
 {
     public class GcCostJourneyStatLevel : NMSTemplate
     {
-        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 0x10)]
+        [NMS(Size = 0x10)]
         public string StatName;
         public int RequiredLevel;
     }

--- a/MBINCompiler/Models/Structs/GcCostJourneyStatLevel.cs
+++ b/MBINCompiler/Models/Structs/GcCostJourneyStatLevel.cs
@@ -1,6 +1,4 @@
-﻿using System.Runtime.InteropServices;
-
-namespace MBINCompiler.Models.Structs
+﻿namespace MBINCompiler.Models.Structs
 {
     public class GcCostJourneyStatLevel : NMSTemplate
     {

--- a/MBINCompiler/Models/Structs/GcCostProduct.cs
+++ b/MBINCompiler/Models/Structs/GcCostProduct.cs
@@ -4,7 +4,7 @@ namespace MBINCompiler.Models.Structs
 {
     public class GcCostProduct : NMSTemplate
     {
-        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 0x10)]
+        [NMS(Size = 0x10)]
         public string Id;
         public int Amount;
     }

--- a/MBINCompiler/Models/Structs/GcCostProduct.cs
+++ b/MBINCompiler/Models/Structs/GcCostProduct.cs
@@ -1,6 +1,4 @@
-﻿using System.Runtime.InteropServices;
-
-namespace MBINCompiler.Models.Structs
+﻿namespace MBINCompiler.Models.Structs
 {
     public class GcCostProduct : NMSTemplate
     {

--- a/MBINCompiler/Models/Structs/GcCostSubstance.cs
+++ b/MBINCompiler/Models/Structs/GcCostSubstance.cs
@@ -4,7 +4,7 @@ namespace MBINCompiler.Models.Structs
 {
     public class GcCostSubstance : NMSTemplate
     {
-        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 0x10)]
+        [NMS(Size = 0x10)]
         public string Id;
         public int Amount;
     }

--- a/MBINCompiler/Models/Structs/GcCostSubstance.cs
+++ b/MBINCompiler/Models/Structs/GcCostSubstance.cs
@@ -1,6 +1,4 @@
-﻿using System.Runtime.InteropServices;
-
-namespace MBINCompiler.Models.Structs
+﻿namespace MBINCompiler.Models.Structs
 {
     public class GcCostSubstance : NMSTemplate
     {

--- a/MBINCompiler/Models/Structs/GcCostTableEntry.cs
+++ b/MBINCompiler/Models/Structs/GcCostTableEntry.cs
@@ -1,6 +1,4 @@
-﻿using System.Runtime.InteropServices;
-
-namespace MBINCompiler.Models.Structs
+﻿namespace MBINCompiler.Models.Structs
 {
     public class GcCostTableEntry : NMSTemplate
     {

--- a/MBINCompiler/Models/Structs/GcCostTableEntry.cs
+++ b/MBINCompiler/Models/Structs/GcCostTableEntry.cs
@@ -4,7 +4,7 @@ namespace MBINCompiler.Models.Structs
 {
     public class GcCostTableEntry : NMSTemplate
     {
-        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 0x10)]
+        [NMS(Size = 0x10)]
         public string Id;
         public NMSTemplate Entry;
     }

--- a/MBINCompiler/Models/Structs/GcCreatureAudioTable.cs
+++ b/MBINCompiler/Models/Structs/GcCreatureAudioTable.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using System.Collections.Generic;
 
 namespace MBINCompiler.Models.Structs
 {

--- a/MBINCompiler/Models/Structs/GcCreatureData.cs
+++ b/MBINCompiler/Models/Structs/GcCreatureData.cs
@@ -5,10 +5,10 @@ namespace MBINCompiler.Models.Structs
 {
     public class GcCreatureData : NMSTemplate
     {
-        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 0x10)]
+        [NMS(Size = 0x10)]
         public string Id;
 
-        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 0x20)]
+        [NMS(Size = 0x20)]
         public string Genus;
 
         public GcCreatureTypes CreatureType;

--- a/MBINCompiler/Models/Structs/GcCreatureData.cs
+++ b/MBINCompiler/Models/Structs/GcCreatureData.cs
@@ -1,5 +1,4 @@
 ﻿using System.Collections.Generic;
-using System.Runtime.InteropServices;
 
 namespace MBINCompiler.Models.Structs
 {

--- a/MBINCompiler/Models/Structs/GcCreatureFilename.cs
+++ b/MBINCompiler/Models/Structs/GcCreatureFilename.cs
@@ -1,6 +1,4 @@
-﻿using System.Runtime.InteropServices;
-
-namespace MBINCompiler.Models.Structs
+﻿namespace MBINCompiler.Models.Structs
 {
     public class GcCreatureFilename : NMSTemplate
     {

--- a/MBINCompiler/Models/Structs/GcCreatureFilename.cs
+++ b/MBINCompiler/Models/Structs/GcCreatureFilename.cs
@@ -4,9 +4,9 @@ namespace MBINCompiler.Models.Structs
 {
     public class GcCreatureFilename : NMSTemplate
     {
-        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 0x10)]
+        [NMS(Size = 0x10)]
         public string ID;
-        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 0x80)]
+        [NMS(Size = 0x80)]
         public string Filename;
     }
 }

--- a/MBINCompiler/Models/Structs/GcCreatureFootParticleSingleData.cs
+++ b/MBINCompiler/Models/Structs/GcCreatureFootParticleSingleData.cs
@@ -1,6 +1,4 @@
-﻿using System.Runtime.InteropServices;
-
-namespace MBINCompiler.Models.Structs
+﻿namespace MBINCompiler.Models.Structs
 {
     public class GcCreatureFootParticleSingleData : NMSTemplate
     {

--- a/MBINCompiler/Models/Structs/GcCreatureFootParticleSingleData.cs
+++ b/MBINCompiler/Models/Structs/GcCreatureFootParticleSingleData.cs
@@ -4,7 +4,7 @@ namespace MBINCompiler.Models.Structs
 {
     public class GcCreatureFootParticleSingleData : NMSTemplate
     {
-        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 0x10)]
+        [NMS(Size = 0x10)]
         public string EffectName;
 
         public float Scale;

--- a/MBINCompiler/Models/Structs/GcCreatureHealthData.cs
+++ b/MBINCompiler/Models/Structs/GcCreatureHealthData.cs
@@ -1,6 +1,4 @@
-﻿using System.Runtime.InteropServices;
-
-namespace MBINCompiler.Models.Structs
+﻿namespace MBINCompiler.Models.Structs
 {
     public class GcCreatureHealthData : NMSTemplate
     {

--- a/MBINCompiler/Models/Structs/GcCreatureHealthData.cs
+++ b/MBINCompiler/Models/Structs/GcCreatureHealthData.cs
@@ -4,15 +4,15 @@ namespace MBINCompiler.Models.Structs
 {
     public class GcCreatureHealthData : NMSTemplate
     {
-        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 0x10)]
+        [NMS(Size = 0x10)]
         public string HurtAnim;
-        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 0x10)]
+        [NMS(Size = 0x10)]
         public string DeathAnim;
-        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 0x10)]
+        [NMS(Size = 0x10)]
         public string DeathEffect;
-        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 0x10)]
+        [NMS(Size = 0x10)]
         public string HurtAudio;
-        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 0x10)]
+        [NMS(Size = 0x10)]
         public string DeathAudio;
     }
 }

--- a/MBINCompiler/Models/Structs/GcCreatureMoveAnimData.cs
+++ b/MBINCompiler/Models/Structs/GcCreatureMoveAnimData.cs
@@ -1,6 +1,4 @@
-﻿using System.Runtime.InteropServices;
-
-namespace MBINCompiler.Models.Structs
+﻿namespace MBINCompiler.Models.Structs
 {
     public class GcCreatureMoveAnimData : NMSTemplate
     {

--- a/MBINCompiler/Models/Structs/GcCreatureMoveAnimData.cs
+++ b/MBINCompiler/Models/Structs/GcCreatureMoveAnimData.cs
@@ -4,11 +4,11 @@ namespace MBINCompiler.Models.Structs
 {
     public class GcCreatureMoveAnimData : NMSTemplate
     {
-        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 0x10)]
+        [NMS(Size = 0x10)]
         public string Anim;
-        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 0x10)]
+        [NMS(Size = 0x10)]
         public string AnimLeft;
-        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 0x10)]
+        [NMS(Size = 0x10)]
         public string AnimRight;
 
         public float AnimSpeed;

--- a/MBINCompiler/Models/Structs/GcCreatureRoleDescription.cs
+++ b/MBINCompiler/Models/Structs/GcCreatureRoleDescription.cs
@@ -20,7 +20,7 @@ namespace MBINCompiler.Models.Structs
         public float ProbabilityOfBeingEnabled;
         public float IncreasedSpawnDistance;
     
-        [NMSAttribute(Ignore = true)]
+        [NMS(Ignore = true)]
         public int Padding;
     }
 }

--- a/MBINCompiler/Models/Structs/GcCreatureRoleDescription.cs
+++ b/MBINCompiler/Models/Structs/GcCreatureRoleDescription.cs
@@ -1,6 +1,4 @@
-﻿using System.Runtime.InteropServices;
-
-namespace MBINCompiler.Models.Structs
+﻿namespace MBINCompiler.Models.Structs
 {
     public class GcCreatureRoleDescription : NMSTemplate
     {

--- a/MBINCompiler/Models/Structs/GcCreatureRoleDescription.cs
+++ b/MBINCompiler/Models/Structs/GcCreatureRoleDescription.cs
@@ -7,7 +7,7 @@ namespace MBINCompiler.Models.Structs
         public GcCreatureRoles CreatureRole;
         public GcCreatureTypes CreatureType;
 
-        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 0x10)]
+        [NMS(Size = 0x10)]
         public string ForceID;
 
         public float MinGroupScale;

--- a/MBINCompiler/Models/Structs/GcCreatureStupidName.cs
+++ b/MBINCompiler/Models/Structs/GcCreatureStupidName.cs
@@ -5,7 +5,7 @@ namespace MBINCompiler.Models.Structs
 {
     public class GcCreatureStupidName : NMSTemplate
     {
-        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 0x10)]
+        [NMS(Size = 0x10)]
         public string Id;
 
         public int Count;

--- a/MBINCompiler/Models/Structs/GcCreatureStupidName.cs
+++ b/MBINCompiler/Models/Structs/GcCreatureStupidName.cs
@@ -1,5 +1,4 @@
 ﻿using System.Collections.Generic;
-using System.Runtime.InteropServices;
 
 namespace MBINCompiler.Models.Structs
 {

--- a/MBINCompiler/Models/Structs/GcCreatureStupidNameTable.cs
+++ b/MBINCompiler/Models/Structs/GcCreatureStupidNameTable.cs
@@ -5,7 +5,7 @@ namespace MBINCompiler.Models.Structs
 {
     public class GcCreatureStupidNameTable : NMSTemplate
     {
-        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 0x80)]
+        [NMS(Size = 0x80)]
         public string StupidUserName;
 
         public List<GcCreatureStupidName> Table;

--- a/MBINCompiler/Models/Structs/GcCreatureStupidNameTable.cs
+++ b/MBINCompiler/Models/Structs/GcCreatureStupidNameTable.cs
@@ -1,5 +1,4 @@
 ﻿using System.Collections.Generic;
-using System.Runtime.InteropServices;
 
 namespace MBINCompiler.Models.Structs
 {

--- a/MBINCompiler/Models/Structs/GcCreatureVocalData.cs
+++ b/MBINCompiler/Models/Structs/GcCreatureVocalData.cs
@@ -1,6 +1,4 @@
-﻿using System.Runtime.InteropServices;
-
-namespace MBINCompiler.Models.Structs
+﻿namespace MBINCompiler.Models.Structs
 {
     public class GcCreatureVocalData : NMSTemplate
     {

--- a/MBINCompiler/Models/Structs/GcCreatureVocalData.cs
+++ b/MBINCompiler/Models/Structs/GcCreatureVocalData.cs
@@ -6,8 +6,7 @@ namespace MBINCompiler.Models.Structs
     {
         public float ScaleBias;
 
-        [MarshalAs(UnmanagedType.ByValArray, SizeConst = 4)]
-        [NMSAttribute(Ignore = true)]
+        [NMS(Size = 4, Ignore = true)]
         public byte[] Padding4;
 
         public GcCreatureVocalSoundData IdleVocal;

--- a/MBINCompiler/Models/Structs/GcCreatureVocalSoundData.cs
+++ b/MBINCompiler/Models/Structs/GcCreatureVocalSoundData.cs
@@ -4,7 +4,7 @@ namespace MBINCompiler.Models.Structs
 {
     public class GcCreatureVocalSoundData : NMSTemplate
     {
-        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 0x10)]
+        [NMS(Size = 0x10)]
         public string Id;
 
         public int VocalEmote;
@@ -19,8 +19,7 @@ namespace MBINCompiler.Models.Structs
         public bool PlayImmediately;
         public bool PlayOnlyOnce;
 
-        [MarshalAs(UnmanagedType.ByValArray, SizeConst = 6)]
-        [NMSAttribute(Ignore = true)]
+        [NMS(Size = 6, Ignore = true)]
         public byte[] Padding22;
     }
 }

--- a/MBINCompiler/Models/Structs/GcCreatureVocalSoundData.cs
+++ b/MBINCompiler/Models/Structs/GcCreatureVocalSoundData.cs
@@ -1,6 +1,4 @@
-﻿using System.Runtime.InteropServices;
-
-namespace MBINCompiler.Models.Structs
+﻿namespace MBINCompiler.Models.Structs
 {
     public class GcCreatureVocalSoundData : NMSTemplate
     {

--- a/MBINCompiler/Models/Structs/GcDebugOptions.cs
+++ b/MBINCompiler/Models/Structs/GcDebugOptions.cs
@@ -27,9 +27,9 @@ namespace MBINCompiler.Models.Structs
 
         /* 0x1C */ public int Monitor;
 
-        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 0x100)]
+        [NMS(Size = 0x100)]
         /* 0x20 */ public string ForceUniverseAddress; // 0x100
-        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 0x100)]
+        [NMS(Size = 0x100)]
         /* 0x120 */ public string ForcePlayerPosition; // 0x100
 
         /* 0x220 */ public bool ForceInitialShip;
@@ -51,9 +51,9 @@ namespace MBINCompiler.Models.Structs
             return new[] { "None", "InNearestStation", "OnNearestPlanet", "OnFurthestPlanet", "NextToPlayerShip", "FromSettings", "OnRandomPlanet", "OnGameStartPlanet", "AwayFromYourShip" };
         }
 
-        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 0x80)]
+        [NMS(Size = 0x80)]
         /* 0x230 */ public string SceneSettings; // 0x80
-        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 0x100)]
+        [NMS(Size = 0x100)]
         /* 0x2B0 */ public string WorkingDirectory; // 0x100
 
         /* 0x3B0 */ public int SolarSystemBoot;
@@ -102,7 +102,7 @@ namespace MBINCompiler.Models.Structs
         /* 0x3DE */ public bool StopSwitchingToSecondaryInteractions;
         /* 0x3E0 */ public int DebugLanguages; // unused?
 
-        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 0x20)]
+        [NMS(Size = 0x20)]
         /* 0x3E4 */ public string AllowedLanguagesFile; // 0x20
         /* 0x404 */ public bool DoAlienLanguage;
         /* 0x408 */ public int ForceInteractionRaceTo;
@@ -113,11 +113,11 @@ namespace MBINCompiler.Models.Structs
         }
         /* 0x410 */ public bool DebugPersistentInteractions;
 
-        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 0x80)]
+        [NMS(Size = 0x80)]
         /* 0x411 */ public string RealityPresetFile; // 0x80
         /* 0x492 */ public short RealityGenerationIteration;
 
-        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 0x80)]
+        [NMS(Size = 0x80)]
         /* 0x494 */ public string DefaultSaveData; // 0x80
         /* 0x514 */ public bool FormatDownloadStorageAreaOnBoot;
         /* 0x515 */ public bool ForceBasicLoadScreen;
@@ -139,7 +139,7 @@ namespace MBINCompiler.Models.Structs
         /* 0x530 */ public bool ShowGPUMemory;
         /* 0x531 */ public bool ShowMempoolOverlay;
 
-        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 0x100)]
+        [NMS(Size = 0x100)]
         /* 0x532 */ public string ShowUniverseAddressOnGalaxyMap; // 0x100
         /* 0x632 */ public bool ShowGraphs;
         /* 0x633 */ public bool GraphCommandBuffer;
@@ -163,9 +163,9 @@ namespace MBINCompiler.Models.Structs
         /* 0x651 */ public bool CompressTextures;
         /* 0x652 */ public bool DebugIBL;
         /* 0x653 */ public bool DisableShadowSwitching;
-        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 0x80)]
+        [NMS(Size = 0x80)]
         /* 0x654 */ public string PipelineFile; // 0x80
-        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 0x80)]
+        [NMS(Size = 0x80)]
         /* 0x6D4 */ public string PipelineFilePS4; // 0x80
         /* 0x754 */ public bool RenderLowFramerate;
         /* 0x755 */ public bool SimulateNoNetworkConnection;
@@ -174,23 +174,23 @@ namespace MBINCompiler.Models.Structs
         {
             return new[] { "None", "ManualURI", "InetProxy" };
         }
-        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 0x80)]
+        [NMS(Size = 0x80)]
         /* 0x75C */ public string ProxyURI; // 0x80
         /* 0x7DC */ public int ServerEnv;
         public string[] ServerEnvValues()
         {
             return new[] { "default", "dev", "qa", "prodqa", "prod", "custom", "pentest" };
         }
-        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 0x80)]
+        [NMS(Size = 0x80)]
         /* 0x7E0 */ public string AuthBaseUrl; // 0x80
         /* 0x860 */ public bool CertificateSecurityBypass;
-        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 0x20)]
+        [NMS(Size = 0x20)]
         /* 0x861 */ public string OverrideUsernameForDev; // 0x20
         /* 0x884 */ public int DiscoveryAutoSyncIntervalSeconds;
         /* 0x888 */ public int DiscoveryTrimLimitOverride;
         /* 0x88C */ public int DiscoveryTrimTriggerOverride;
         /* 0x890 */ public bool EnableSynergy;
-        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 0x20)]
+        [NMS(Size = 0x20)]
         /* 0x891 */ public string SynergyServer; // 0x20
         /* 0x8B4 */ public int SynergyPort;
         /* 0x8B8 */ public int MaxNumDebugMessages;
@@ -199,19 +199,19 @@ namespace MBINCompiler.Models.Structs
         /* 0x8C4 */ public bool UseProcTextureDebugger;
         /* 0x8C8 */ public int ProceduralModelsShown;
         /* 0x8CC */ public int ProceduralModelBatchSize;
-        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 0x80)]
+        [NMS(Size = 0x80)]
         /* 0x8D0 */ public string DebugFont; // 0x80
-        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 0x80)]
+        [NMS(Size = 0x80)]
         /* 0x950 */ public string DebugFontTexture; // 0x80
-        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 0x80)]
+        [NMS(Size = 0x80)]
         /* 0x9D0 */ public string CursorTexture; // 0x80
-        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 0x80)]
+        [NMS(Size = 0x80)]
         /* 0xA50 */ public string PauseTexture; // 0x80
-        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 0x80)]
+        [NMS(Size = 0x80)]
         /* 0xAD0 */ public string PlayTexture; // 0x80
-        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 0x80)]
+        [NMS(Size = 0x80)]
         /* 0xB50 */ public string StepTexture; // 0x80
-        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 0x80)]
+        [NMS(Size = 0x80)]
         /* 0xBD0 */ public string RenderToTexture; // 0x80
         /* 0xC50 */ public bool HmdEnable;
         /* 0xC51 */ public bool HmdOutput;

--- a/MBINCompiler/Models/Structs/GcDebugOptions.cs
+++ b/MBINCompiler/Models/Structs/GcDebugOptions.cs
@@ -1,6 +1,4 @@
-﻿using System.Runtime.InteropServices;
-
-namespace MBINCompiler.Models.Structs
+﻿namespace MBINCompiler.Models.Structs
 {
     public class GcDebugOptions : NMSTemplate
     {

--- a/MBINCompiler/Models/Structs/GcEntitlementRewardData.cs
+++ b/MBINCompiler/Models/Structs/GcEntitlementRewardData.cs
@@ -4,16 +4,16 @@ namespace MBINCompiler.Models.Structs
 {
     public class GcEntitlementRewardData : NMSTemplate
     {
-        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 0x20)]
+        [NMS(Size = 0x20)]
         public string EntitlementId;
 
-        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 0x10)]
+        [NMS(Size = 0x10)]
         public string RewardId;
 
-        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 0x20)]
+        [NMS(Size = 0x20)]
         public string Name;
 
-        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 0x20)]
+        [NMS(Size = 0x20)]
         public string Error;
     }
 }

--- a/MBINCompiler/Models/Structs/GcEntitlementRewardData.cs
+++ b/MBINCompiler/Models/Structs/GcEntitlementRewardData.cs
@@ -1,6 +1,4 @@
-﻿using System.Runtime.InteropServices;
-
-namespace MBINCompiler.Models.Structs
+﻿namespace MBINCompiler.Models.Structs
 {
     public class GcEntitlementRewardData : NMSTemplate
     {

--- a/MBINCompiler/Models/Structs/GcExactResource.cs
+++ b/MBINCompiler/Models/Structs/GcExactResource.cs
@@ -1,6 +1,4 @@
-﻿using System.Runtime.InteropServices;
-
-namespace MBINCompiler.Models.Structs
+﻿namespace MBINCompiler.Models.Structs
 {
     public class GcExactResource : NMSTemplate
     {

--- a/MBINCompiler/Models/Structs/GcExactResource.cs
+++ b/MBINCompiler/Models/Structs/GcExactResource.cs
@@ -4,7 +4,7 @@ namespace MBINCompiler.Models.Structs
 {
     public class GcExactResource : NMSTemplate
     {
-        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 0x80)]
+        [NMS(Size = 0x80)]
         public string Filename;
         public GcSeed GenerationSeed;
     }

--- a/MBINCompiler/Models/Structs/GcFogProperties.cs
+++ b/MBINCompiler/Models/Structs/GcFogProperties.cs
@@ -21,8 +21,7 @@ namespace MBINCompiler.Models.Structs
         public float DepthOfFieldFade;
         public bool IsRaining;
 
-        [MarshalAs(UnmanagedType.ByValArray, SizeConst = 0x3)]
-        [NMSAttribute(Ignore = true)]
+        [NMS(Size = 0x3, Ignore = true)]
         public byte[] Padding;
     }
 }

--- a/MBINCompiler/Models/Structs/GcFogProperties.cs
+++ b/MBINCompiler/Models/Structs/GcFogProperties.cs
@@ -1,6 +1,4 @@
-﻿using System.Runtime.InteropServices;
-
-namespace MBINCompiler.Models.Structs
+﻿namespace MBINCompiler.Models.Structs
 {
     public class GcFogProperties : NMSTemplate
     {

--- a/MBINCompiler/Models/Structs/GcFontData.cs
+++ b/MBINCompiler/Models/Structs/GcFontData.cs
@@ -5,7 +5,7 @@ namespace MBINCompiler.Models.Structs
 {
 	public class GcFontData : NMSTemplate
 	{
-		[MarshalAs(UnmanagedType.ByValTStr, SizeConst = 0x80)]
+		[NMS(Size = 0x80)]
 		public string File;
 		public int MinCharWidth;
 	}

--- a/MBINCompiler/Models/Structs/GcFontData.cs
+++ b/MBINCompiler/Models/Structs/GcFontData.cs
@@ -1,6 +1,3 @@
-using System.Collections.Generic;
-using System.Runtime.InteropServices;
-
 namespace MBINCompiler.Models.Structs
 {
 	public class GcFontData : NMSTemplate

--- a/MBINCompiler/Models/Structs/GcFontTable.cs
+++ b/MBINCompiler/Models/Structs/GcFontTable.cs
@@ -1,6 +1,3 @@
-using System.Collections.Generic;
-using System.Runtime.InteropServices;
-
 namespace MBINCompiler.Models.Structs
 {
 	public class GcFontTable : NMSTemplate

--- a/MBINCompiler/Models/Structs/GcGenericRewardTableEntry.cs
+++ b/MBINCompiler/Models/Structs/GcGenericRewardTableEntry.cs
@@ -4,7 +4,7 @@ namespace MBINCompiler.Models.Structs
 {
     public class GcGenericRewardTableEntry : NMSTemplate
     {
-        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 0x10)]
+        [NMS(Size = 0x10)]
         public string Id;
         public GcRewardTableItemList Common;
     }

--- a/MBINCompiler/Models/Structs/GcGenericRewardTableEntry.cs
+++ b/MBINCompiler/Models/Structs/GcGenericRewardTableEntry.cs
@@ -1,6 +1,4 @@
-﻿using System.Runtime.InteropServices;
-
-namespace MBINCompiler.Models.Structs
+﻿namespace MBINCompiler.Models.Structs
 {
     public class GcGenericRewardTableEntry : NMSTemplate
     {

--- a/MBINCompiler/Models/Structs/GcHUDComponent.cs
+++ b/MBINCompiler/Models/Structs/GcHUDComponent.cs
@@ -1,6 +1,4 @@
-﻿using System.Runtime.InteropServices;
-
-namespace MBINCompiler.Models.Structs
+﻿namespace MBINCompiler.Models.Structs
 {
     public class GcHUDComponent : NMSTemplate
     {

--- a/MBINCompiler/Models/Structs/GcHUDComponent.cs
+++ b/MBINCompiler/Models/Structs/GcHUDComponent.cs
@@ -4,7 +4,7 @@ namespace MBINCompiler.Models.Structs
 {
     public class GcHUDComponent : NMSTemplate
     {
-        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 0x10)]
+        [NMS(Size = 0x10)]
         public string Id;
 
         public int PosX;

--- a/MBINCompiler/Models/Structs/GcHUDImageData.cs
+++ b/MBINCompiler/Models/Structs/GcHUDImageData.cs
@@ -6,7 +6,7 @@ namespace MBINCompiler.Models.Structs
     {
         public GcHUDComponent Data;
 
-        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 0x80)]
+        [NMS(Size = 0x80)]
         public string Image;
 
         public Colour Colour;

--- a/MBINCompiler/Models/Structs/GcHUDImageData.cs
+++ b/MBINCompiler/Models/Structs/GcHUDImageData.cs
@@ -1,6 +1,4 @@
-﻿using System.Runtime.InteropServices;
-
-namespace MBINCompiler.Models.Structs
+﻿namespace MBINCompiler.Models.Structs
 {
     public class GcHUDImageData : NMSTemplate
     {

--- a/MBINCompiler/Models/Structs/GcHUDTextData.cs
+++ b/MBINCompiler/Models/Structs/GcHUDTextData.cs
@@ -1,6 +1,4 @@
-﻿using System.Runtime.InteropServices;
-
-namespace MBINCompiler.Models.Structs
+﻿namespace MBINCompiler.Models.Structs
 {
     public class GcHUDTextData : NMSTemplate
     {

--- a/MBINCompiler/Models/Structs/GcHUDTextData.cs
+++ b/MBINCompiler/Models/Structs/GcHUDTextData.cs
@@ -6,7 +6,7 @@ namespace MBINCompiler.Models.Structs
     {
         public GcHUDComponent Data;
 
-        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 0x80)]
+        [NMS(Size = 0x80)]
         public string Text;
 
         [NMS(Size = 8, Ignore = true)]

--- a/MBINCompiler/Models/Structs/GcInteractionBuffer.cs
+++ b/MBINCompiler/Models/Structs/GcInteractionBuffer.cs
@@ -1,6 +1,4 @@
-﻿using System.Collections.Generic;
-
-namespace MBINCompiler.Models.Structs
+﻿namespace MBINCompiler.Models.Structs
 {
     public class GcInteractionBuffer : NMSTemplate // 0x7D10 bytes
     {

--- a/MBINCompiler/Models/Structs/GcInventoryElement.cs
+++ b/MBINCompiler/Models/Structs/GcInventoryElement.cs
@@ -5,7 +5,7 @@ namespace MBINCompiler.Models.Structs
     public class GcInventoryElement : NMSTemplate
     {
         public GcInventoryType Type;
-        [NMSAttribute(Ignore = true)]
+        [NMS(Ignore = true)]
         public int EmptyNode1;
         [NMS(Size = 0x10)]
         public string Id;
@@ -13,7 +13,7 @@ namespace MBINCompiler.Models.Structs
         public int MaxAmount;
         public float DamageFactor;
         public GcInventoryIndex Index;
-        [NMSAttribute(Ignore = true)]
+        [NMS(Ignore = true)]
         public int EmptyNode2;
     }
 }

--- a/MBINCompiler/Models/Structs/GcInventoryElement.cs
+++ b/MBINCompiler/Models/Structs/GcInventoryElement.cs
@@ -7,7 +7,7 @@ namespace MBINCompiler.Models.Structs
         public GcInventoryType Type;
         [NMSAttribute(Ignore = true)]
         public int EmptyNode1;
-        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 0x10)]
+        [NMS(Size = 0x10)]
         public string Id;
         public int Amount;
         public int MaxAmount;

--- a/MBINCompiler/Models/Structs/GcInventoryElement.cs
+++ b/MBINCompiler/Models/Structs/GcInventoryElement.cs
@@ -1,6 +1,4 @@
-﻿using System.Runtime.InteropServices;
-
-namespace MBINCompiler.Models.Structs
+﻿namespace MBINCompiler.Models.Structs
 {
     public class GcInventoryElement : NMSTemplate
     {

--- a/MBINCompiler/Models/Structs/GcInventoryLayout.cs
+++ b/MBINCompiler/Models/Structs/GcInventoryLayout.cs
@@ -1,6 +1,4 @@
-﻿using System.Runtime.InteropServices;
-
-namespace MBINCompiler.Models.Structs
+﻿namespace MBINCompiler.Models.Structs
 {
     public class GcInventoryLayout : NMSTemplate
     {

--- a/MBINCompiler/Models/Structs/GcInventoryLayout.cs
+++ b/MBINCompiler/Models/Structs/GcInventoryLayout.cs
@@ -5,11 +5,11 @@ namespace MBINCompiler.Models.Structs
     public class GcInventoryLayout : NMSTemplate
     {
         public int Slots;
-        [NMSAttribute(Ignore = true)]
+        [NMS(Ignore = true)]
         public int EmptyNode1;
         public GcSeed Seed;
         public int Level;
-        [NMSAttribute(Ignore = true)]
+        [NMS(Ignore = true)]
         public int EmptyNode2;
     }
 }

--- a/MBINCompiler/Models/Structs/GcInventoryTableEntry.cs
+++ b/MBINCompiler/Models/Structs/GcInventoryTableEntry.cs
@@ -4,7 +4,7 @@ namespace MBINCompiler.Models.Structs
 {
     public class GcInventoryTableEntry : NMSTemplate
     {
-        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 0x10)]
+        [NMS(Size = 0x10)]
         public string Id;
         public int MinSize;
         public int MaxSize;
@@ -14,8 +14,7 @@ namespace MBINCompiler.Models.Structs
             return new[] { "SciSmall", "SciMedium", "SciLarge", "FgtSmall", "FgtMedium", "FgtLarge", "ShuSmall", "ShtMedium", "ShtLarge", "DrpSmall", "DrpMedium", "DrpLarge", "WeaponSmall", "WeaponMedium", "WeaponLarge" }; // Shu/Sht spelling mistake(?) is from the exe
         }
 
-        [MarshalAs(UnmanagedType.ByValArray, SizeConst = 4)]
-        [NMSAttribute(Ignore = true)]
+        [NMS(Size = 4, Ignore = true)]
         public byte[] Padding1C;
     }
 }

--- a/MBINCompiler/Models/Structs/GcInventoryTableEntry.cs
+++ b/MBINCompiler/Models/Structs/GcInventoryTableEntry.cs
@@ -1,6 +1,4 @@
-﻿using System.Runtime.InteropServices;
-
-namespace MBINCompiler.Models.Structs
+﻿namespace MBINCompiler.Models.Structs
 {
     public class GcInventoryTableEntry : NMSTemplate
     {

--- a/MBINCompiler/Models/Structs/GcJourneyMilestoneData.cs
+++ b/MBINCompiler/Models/Structs/GcJourneyMilestoneData.cs
@@ -1,6 +1,4 @@
-﻿using System.Runtime.InteropServices;
-
-namespace MBINCompiler.Models.Structs
+﻿namespace MBINCompiler.Models.Structs
 {
     public class GcJourneyMilestoneData : NMSTemplate
     {

--- a/MBINCompiler/Models/Structs/GcJourneyMilestoneData.cs
+++ b/MBINCompiler/Models/Structs/GcJourneyMilestoneData.cs
@@ -4,13 +4,12 @@ namespace MBINCompiler.Models.Structs
 {
     public class GcJourneyMilestoneData : NMSTemplate
     {
-        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 0x10)]
+        [NMS(Size = 0x10)]
         public string JourneyMilestoneId;
         public int PointsToUnlock;
-        [MarshalAs(UnmanagedType.ByValArray, SizeConst = 4)]
-        [NMSAttribute(Ignore = true)]
+        [NMS(Size = 4, Ignore = true)]
         public byte[] Padding14;
-        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 0x20)]
+        [NMS(Size = 0x20)]
         public string JourneyMilestoneTitle;
     }
 }

--- a/MBINCompiler/Models/Structs/GcLandingHelperComponentData.cs
+++ b/MBINCompiler/Models/Structs/GcLandingHelperComponentData.cs
@@ -1,6 +1,4 @@
-﻿using System.Collections.Generic;
-
-namespace MBINCompiler.Models.Structs
+﻿namespace MBINCompiler.Models.Structs
 {
     public class GcLandingHelperComponentData : NMSTemplate
     {

--- a/MBINCompiler/Models/Structs/GcLootComponentData.cs
+++ b/MBINCompiler/Models/Structs/GcLootComponentData.cs
@@ -1,6 +1,4 @@
-﻿using System.Collections.Generic;
-
-namespace MBINCompiler.Models.Structs
+﻿namespace MBINCompiler.Models.Structs
 {
     public class GcLootComponentData : NMSTemplate
     {

--- a/MBINCompiler/Models/Structs/GcMarkerComponentData.cs
+++ b/MBINCompiler/Models/Structs/GcMarkerComponentData.cs
@@ -1,6 +1,4 @@
-﻿using System.Collections.Generic;
-
-namespace MBINCompiler.Models.Structs
+﻿namespace MBINCompiler.Models.Structs
 {
     public class GcMarkerComponentData : NMSTemplate
     {

--- a/MBINCompiler/Models/Structs/GcNGuiElementData.cs
+++ b/MBINCompiler/Models/Structs/GcNGuiElementData.cs
@@ -13,8 +13,7 @@ namespace MBINCompiler.Models.Structs
 
         public bool IsHidden;
 
-        [MarshalAs( UnmanagedType.ByValArray, SizeConst = 0x3 )]
-        [NMSAttribute(Ignore = true)]
+        [NMS(Size = 0x3, Ignore = true)]
         public byte[] Padding29;
 
         public GcNGuiLayoutData Layout;

--- a/MBINCompiler/Models/Structs/GcNGuiElementData.cs
+++ b/MBINCompiler/Models/Structs/GcNGuiElementData.cs
@@ -18,7 +18,7 @@ namespace MBINCompiler.Models.Structs
 
         public GcNGuiLayoutData Layout;
 
-        [NMS(Size = 4)]
+        [NMS(Size = 4, Ignore = true)]
         public byte[] Padding5C;
     }
 }

--- a/MBINCompiler/Models/Structs/GcNGuiElementData.cs
+++ b/MBINCompiler/Models/Structs/GcNGuiElementData.cs
@@ -1,6 +1,4 @@
-﻿using System.Runtime.InteropServices;
-
-namespace MBINCompiler.Models.Structs
+﻿namespace MBINCompiler.Models.Structs
 {
     public class GcNGuiElementData : NMSTemplate
     {

--- a/MBINCompiler/Models/Structs/GcNGuiLayoutData.cs
+++ b/MBINCompiler/Models/Structs/GcNGuiLayoutData.cs
@@ -24,8 +24,7 @@ namespace MBINCompiler.Models.Structs
         public TkNGuiAlignment Align;
         public bool SlowCursorOnHover;
 
-        [MarshalAs( UnmanagedType.ByValArray, SizeConst = 0x7 )]
-        [NMSAttribute(Ignore = true)]
+        [NMS(Size = 0x7, Ignore = true)]
         public byte[] Padding4;
     }
 }

--- a/MBINCompiler/Models/Structs/GcNGuiLayoutData.cs
+++ b/MBINCompiler/Models/Structs/GcNGuiLayoutData.cs
@@ -1,6 +1,4 @@
-﻿using System.Runtime.InteropServices;
-
-namespace MBINCompiler.Models.Structs
+﻿namespace MBINCompiler.Models.Structs
 {
     public class GcNGuiLayoutData : NMSTemplate
     {

--- a/MBINCompiler/Models/Structs/GcNGuiLayoutData.cs
+++ b/MBINCompiler/Models/Structs/GcNGuiLayoutData.cs
@@ -18,7 +18,7 @@ namespace MBINCompiler.Models.Structs
         public bool AnchorPercent;
         public bool SameLine;
 
-        [NMS(Size = 1)]
+        [NMS(Size = 1, Ignore = true)]
         public byte[] Padding1F;
 
         public TkNGuiAlignment Align;

--- a/MBINCompiler/Models/Structs/GcNGuiTextData.cs
+++ b/MBINCompiler/Models/Structs/GcNGuiTextData.cs
@@ -15,8 +15,7 @@ namespace MBINCompiler.Models.Structs
         public string Text;
 
         public bool Special;
-        [MarshalAs( UnmanagedType.ByValArray, SizeConst = 0xF )]
-        [NMSAttribute(Ignore = true)]
+        [NMS(Size = 0xF, Ignore = true)]
         public byte[] Padding1;
     }
 }

--- a/MBINCompiler/Models/Structs/GcNGuiTextData.cs
+++ b/MBINCompiler/Models/Structs/GcNGuiTextData.cs
@@ -1,6 +1,4 @@
-﻿using System.Runtime.InteropServices;
-
-namespace MBINCompiler.Models.Structs
+﻿namespace MBINCompiler.Models.Structs
 {
     public class GcNGuiTextData : NMSTemplate
     {

--- a/MBINCompiler/Models/Structs/GcNPCComponentData.cs
+++ b/MBINCompiler/Models/Structs/GcNPCComponentData.cs
@@ -1,6 +1,4 @@
-﻿using System.Collections.Generic;
-
-namespace MBINCompiler.Models.Structs
+﻿namespace MBINCompiler.Models.Structs
 {
     public class GcNPCComponentData : NMSTemplate
     {

--- a/MBINCompiler/Models/Structs/GcNodeActivationAction.cs
+++ b/MBINCompiler/Models/Structs/GcNodeActivationAction.cs
@@ -1,6 +1,4 @@
-﻿using System.Collections.Generic;
-
-namespace MBINCompiler.Models.Structs
+﻿namespace MBINCompiler.Models.Structs
 {
     public class GcNodeActivationAction : NMSTemplate
     {

--- a/MBINCompiler/Models/Structs/GcObjectPlacementComponentData.cs
+++ b/MBINCompiler/Models/Structs/GcObjectPlacementComponentData.cs
@@ -1,6 +1,4 @@
-﻿using System.Collections.Generic;
-
-namespace MBINCompiler.Models.Structs
+﻿namespace MBINCompiler.Models.Structs
 {
     public class GcObjectPlacementComponentData : NMSTemplate
     {

--- a/MBINCompiler/Models/Structs/GcOutpostLSystemPair.cs
+++ b/MBINCompiler/Models/Structs/GcOutpostLSystemPair.cs
@@ -1,6 +1,4 @@
-﻿using System.Collections.Generic;
-
-namespace MBINCompiler.Models.Structs
+﻿namespace MBINCompiler.Models.Structs
 {
     public class GcOutpostLSystemPair : NMSTemplate // 0x320 bytes
     {

--- a/MBINCompiler/Models/Structs/GcPainAction.cs
+++ b/MBINCompiler/Models/Structs/GcPainAction.cs
@@ -1,6 +1,4 @@
-﻿using System.Collections.Generic;
-
-namespace MBINCompiler.Models.Structs
+﻿namespace MBINCompiler.Models.Structs
 {
     public class GcPainAction : NMSTemplate
     {

--- a/MBINCompiler/Models/Structs/GcParticleAction.cs
+++ b/MBINCompiler/Models/Structs/GcParticleAction.cs
@@ -1,6 +1,4 @@
-﻿using System.Collections.Generic;
-
-namespace MBINCompiler.Models.Structs
+﻿namespace MBINCompiler.Models.Structs
 {
     public class GcParticleAction : NMSTemplate
     {

--- a/MBINCompiler/Models/Structs/GcPlanetWeatherColourData.cs
+++ b/MBINCompiler/Models/Structs/GcPlanetWeatherColourData.cs
@@ -12,7 +12,7 @@ namespace MBINCompiler.Models.Structs
         public Colour FogColour;
         public Colour HeightFogColour;
 
-        [MarshalAs(UnmanagedType.ByValArray, SizeConst = 0x10)]
+        [NMS(Size = 0x10)]
         public byte[] SkyGradientSpeed; // not sure what type this is?
 
         public Colour LightColour;

--- a/MBINCompiler/Models/Structs/GcPlanetWeatherColourData.cs
+++ b/MBINCompiler/Models/Structs/GcPlanetWeatherColourData.cs
@@ -1,6 +1,4 @@
-﻿using System.Runtime.InteropServices;
-
-namespace MBINCompiler.Models.Structs
+﻿namespace MBINCompiler.Models.Structs
 {
     public class GcPlanetWeatherColourData : NMSTemplate
     {

--- a/MBINCompiler/Models/Structs/GcPlayAnimAction.cs
+++ b/MBINCompiler/Models/Structs/GcPlayAnimAction.cs
@@ -1,6 +1,4 @@
-﻿using System.Collections.Generic;
-
-namespace MBINCompiler.Models.Structs
+﻿namespace MBINCompiler.Models.Structs
 {
     public class GcPlayAnimAction : NMSTemplate
     {

--- a/MBINCompiler/Models/Structs/GcPlayAudioAction.cs
+++ b/MBINCompiler/Models/Structs/GcPlayAudioAction.cs
@@ -1,6 +1,4 @@
-﻿using System.Collections.Generic;
-
-namespace MBINCompiler.Models.Structs
+﻿namespace MBINCompiler.Models.Structs
 {
     public class GcPlayAudioAction : NMSTemplate
     {

--- a/MBINCompiler/Models/Structs/GcPlayerDamageData.cs
+++ b/MBINCompiler/Models/Structs/GcPlayerDamageData.cs
@@ -1,6 +1,4 @@
-﻿using System.Runtime.InteropServices;
-
-namespace MBINCompiler.Models.Structs
+﻿namespace MBINCompiler.Models.Structs
 {
     public class GcPlayerDamageData : NMSTemplate
     {

--- a/MBINCompiler/Models/Structs/GcPlayerDamageData.cs
+++ b/MBINCompiler/Models/Structs/GcPlayerDamageData.cs
@@ -4,27 +4,25 @@ namespace MBINCompiler.Models.Structs
 {
     public class GcPlayerDamageData : NMSTemplate
     {
-        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 0x10)]
+        [NMS(Size = 0x10)]
         public string Id;
-        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 0x20)]
+        [NMS(Size = 0x20)]
         public string DeathMessage;
         public TkTextureResource HitIcon;
-        [MarshalAs(UnmanagedType.ByValArray, SizeConst = 4)]
-        [NMSAttribute(Ignore = true)]
+        [NMS(Size = 4, Ignore = true)]
         public byte[] PaddingB4;
-        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 0x20)]
+        [NMS(Size = 0x20)]
         public string HitMessage;
-        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 0x20)]
+        [NMS(Size = 0x20)]
         public string CriticalHitMessage;
         public float Damage;
         public float PushForce;
         public float CameraTurn;
-        [MarshalAs(UnmanagedType.ByValArray, SizeConst = 4)]
-        [NMSAttribute(Ignore = true)]
+        [NMS(Size = 4, Ignore = true)]
         public byte[] Padding104;
-        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 0x10)]
+        [NMS(Size = 0x10)]
         public string CameraShakeShield;
-        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 0x10)]
+        [NMS(Size = 0x10)]
         public string CameraShakeNoShield;
     }
 }

--- a/MBINCompiler/Models/Structs/GcPlayerMissionProgressMapEntry.cs
+++ b/MBINCompiler/Models/Structs/GcPlayerMissionProgressMapEntry.cs
@@ -4,14 +4,13 @@ namespace MBINCompiler.Models.Structs
 {
     public class GcPlayerMissionProgressMapEntry : NMSTemplate
     {
-        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 0x10)]
+        [NMS(Size = 0x10)]
         public string Mission;
         public int MinProgress;
         public int MaxProgress;
         public int NewProgress;
 
-        [MarshalAs(UnmanagedType.ByValArray, SizeConst = 4)]
-        [NMSAttribute(Ignore = true)]
+        [NMS(Size = 4, Ignore = true)]
         public byte[] Padding1C;
     }
 }

--- a/MBINCompiler/Models/Structs/GcPlayerMissionProgressMapEntry.cs
+++ b/MBINCompiler/Models/Structs/GcPlayerMissionProgressMapEntry.cs
@@ -1,6 +1,4 @@
-﻿using System.Runtime.InteropServices;
-
-namespace MBINCompiler.Models.Structs
+﻿namespace MBINCompiler.Models.Structs
 {
     public class GcPlayerMissionProgressMapEntry : NMSTemplate
     {

--- a/MBINCompiler/Models/Structs/GcPlayerNearbyEvent.cs
+++ b/MBINCompiler/Models/Structs/GcPlayerNearbyEvent.cs
@@ -1,6 +1,4 @@
-﻿using System.Collections.Generic;
-
-namespace MBINCompiler.Models.Structs
+﻿namespace MBINCompiler.Models.Structs
 {
     public class GcPlayerNearbyEvent : NMSTemplate
     {

--- a/MBINCompiler/Models/Structs/GcPlayerSpawnStateData.cs
+++ b/MBINCompiler/Models/Structs/GcPlayerSpawnStateData.cs
@@ -15,8 +15,7 @@ namespace MBINCompiler.Models.Structs
             return new[] { "OnFoot", "InShip", "OnStation" };
         }
 
-        [MarshalAs(UnmanagedType.ByValArray, SizeConst = 0xC)]
-        [NMSAttribute(Ignore = true)]
+        [NMS(Size = 0xC, Ignore = true)]
         public byte[] Padding44;
     }
 }

--- a/MBINCompiler/Models/Structs/GcPlayerSpawnStateData.cs
+++ b/MBINCompiler/Models/Structs/GcPlayerSpawnStateData.cs
@@ -1,7 +1,4 @@
-﻿using System.Collections.Generic;
-using System.Runtime.InteropServices;
-
-namespace MBINCompiler.Models.Structs
+﻿namespace MBINCompiler.Models.Structs
 {
     public class GcPlayerSpawnStateData : NMSTemplate
     {

--- a/MBINCompiler/Models/Structs/GcPrimaryAxis.cs
+++ b/MBINCompiler/Models/Structs/GcPrimaryAxis.cs
@@ -1,6 +1,4 @@
-﻿using System.Collections.Generic;
-
-namespace MBINCompiler.Models.Structs
+﻿namespace MBINCompiler.Models.Structs
 {
     public class GcPrimaryAxis : NMSTemplate
     {

--- a/MBINCompiler/Models/Structs/GcProductData.cs
+++ b/MBINCompiler/Models/Structs/GcProductData.cs
@@ -31,9 +31,9 @@ namespace MBINCompiler.Models.Structs
         public bool SpecificChargeOnly;
         public float NormalisedValueOnWorld;
         public float NormalisedValueOffWorld;
-        [NMSAttribute(Ignore = true)]
+        [NMS(Ignore = true)]
         public int EmptyNode1;
-        [NMSAttribute(Ignore = true)]
+        [NMS(Ignore = true)]
         public int EmptyNode2;
     }
 }

--- a/MBINCompiler/Models/Structs/GcProductData.cs
+++ b/MBINCompiler/Models/Structs/GcProductData.cs
@@ -1,5 +1,4 @@
-﻿using System.Runtime.InteropServices;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 
 namespace MBINCompiler.Models.Structs
 {

--- a/MBINCompiler/Models/Structs/GcProductData.cs
+++ b/MBINCompiler/Models/Structs/GcProductData.cs
@@ -5,15 +5,15 @@ namespace MBINCompiler.Models.Structs
 {
     public class GcProductData : NMSTemplate
     {
-        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 0x10)]
+        [NMS(Size = 0x10)]
         public string Id;
-        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 0x80)]
+        [NMS(Size = 0x80)]
         public string Name;
-        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 0x80)]
+        [NMS(Size = 0x80)]
         public string NameLower;
         public VariableSizeString Subtitle;
         public VariableSizeString Description;
-        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 0x20)]
+        [NMS(Size = 0x20)]
         public string Hint;
         public TkModelResource Debis;
         public int BaseValue;

--- a/MBINCompiler/Models/Structs/GcProjectileData.cs
+++ b/MBINCompiler/Models/Structs/GcProjectileData.cs
@@ -37,7 +37,7 @@ namespace MBINCompiler.Models.Structs
         [NMS(Size = 0x10)]
         /* 0x318 */ public string DefaultImpact;
         /* 0x328 */ public List<GcProjectileImpactData> Impacts;
-        [NMS(Size = 8)]
+        [NMS(Size = 8, Ignore = true)]
         /* 0x338 */ public byte[] Padding338;
     }
 }

--- a/MBINCompiler/Models/Structs/GcRealityIconTable.cs
+++ b/MBINCompiler/Models/Structs/GcRealityIconTable.cs
@@ -4,16 +4,16 @@ namespace MBINCompiler.Models.Structs
 {
     public class GcRealityIconTable : NMSTemplate
     {
-        [NMSAttribute(Size = 6, EnumValue = new string[6] { "None", "NoOxygen", "ExtremeHeat", "ExtremeCold", "ToxicGas", "Radiation" })]
+        [NMS(Size = 6, EnumValue = new string[6] { "None", "NoOxygen", "ExtremeHeat", "ExtremeCold", "ToxicGas", "Radiation" })]
         public TkTextureResource[] HazardIcons;
 
-        [NMSAttribute(Size = 5, EnumValue = new string[5] { "Commodity", "Technology", "Fuel", "Tradeable", "Special" })]
+        [NMS(Size = 5, EnumValue = new string[5] { "Commodity", "Technology", "Fuel", "Tradeable", "Special" })]
         public TkTextureResource[] SubstanceCategoryIcons;
 
-        [NMSAttribute(Size = 4, EnumValue = new string[4] { "Component", "Device", "Consumable", "Curiosity" })]
+        [NMS(Size = 4, EnumValue = new string[4] { "Component", "Device", "Consumable", "Curiosity" })]
         public TkTextureResource[] ProductCategoryIcons;
 
-        [NMSAttribute(Size = 20, EnumValue = new string[20] { "Stamina", "NoStamina", "EnergyCharge", "Scanner", "NoScanner", "Grave", "Resources", "Inventory", "InventoryFull", "RareItems", "Pirates", "PirateScan", "Drone", "Quad", "Walker", "DroneOff", "Police", "AtlasStation", "BlackHole", "SaveGame" })]
+        [NMS(Size = 20, EnumValue = new string[20] { "Stamina", "NoStamina", "EnergyCharge", "Scanner", "NoScanner", "Grave", "Resources", "Inventory", "InventoryFull", "RareItems", "Pirates", "PirateScan", "Drone", "Quad", "Walker", "DroneOff", "Police", "AtlasStation", "BlackHole", "SaveGame" })]
         public TkTextureResource[] GameIcons;
     }
 }

--- a/MBINCompiler/Models/Structs/GcRealityIconTable.cs
+++ b/MBINCompiler/Models/Structs/GcRealityIconTable.cs
@@ -1,6 +1,4 @@
-﻿using System.Runtime.InteropServices;
-
-namespace MBINCompiler.Models.Structs
+﻿namespace MBINCompiler.Models.Structs
 {
     public class GcRealityIconTable : NMSTemplate
     {

--- a/MBINCompiler/Models/Structs/GcRealityManagerData.cs
+++ b/MBINCompiler/Models/Structs/GcRealityManagerData.cs
@@ -1,5 +1,4 @@
 ﻿using System.Collections.Generic;
-using System.Runtime.InteropServices;
 
 namespace MBINCompiler.Models.Structs
 {

--- a/MBINCompiler/Models/Structs/GcRealityManagerData.cs
+++ b/MBINCompiler/Models/Structs/GcRealityManagerData.cs
@@ -11,25 +11,25 @@ namespace MBINCompiler.Models.Structs
         [NMSAttribute(Size = 7, EnumValue = new string[7] { "Unknown", "SolarSystem", "Planet", "Animal", "Flora", "Mineral", "Sector" })]
         public GcDiscoveryWorth[] DiscoveryWorth;
 
-        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 0x80)]
+        [NMS(Size = 0x80)]
         public string TechnologyTable;
-        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 0x80)]
+        [NMS(Size = 0x80)]
         public string SubstanceTable;
-        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 0x80)]
+        [NMS(Size = 0x80)]
         public string ProductTable;
-        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 0x80)]
+        [NMS(Size = 0x80)]
         public string AlienWordsTable;
-        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 0x80)]
+        [NMS(Size = 0x80)]
         public string AlienPuzzlesTable;
-        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 0x80)]
+        [NMS(Size = 0x80)]
         public string RewardTable;
-        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 0x80)]
+        [NMS(Size = 0x80)]
         public string RewardDestructTable;
-        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 0x80)]
+        [NMS(Size = 0x80)]
         public string InventoryTable;
-        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 0x80)]
+        [NMS(Size = 0x80)]
         public string DamageTable;
-        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 0x80)]
+        [NMS(Size = 0x80)]
         public string CostTable;
 
         public GcRealityIconTable Icons;

--- a/MBINCompiler/Models/Structs/GcRealityManagerData.cs
+++ b/MBINCompiler/Models/Structs/GcRealityManagerData.cs
@@ -8,7 +8,7 @@ namespace MBINCompiler.Models.Structs
         public float RealityIteration;
 
         // TODO: Probably keep these values in a static class.
-        [NMSAttribute(Size = 7, EnumValue = new string[7] { "Unknown", "SolarSystem", "Planet", "Animal", "Flora", "Mineral", "Sector" })]
+        [NMS(Size = 7, EnumValue = new string[7] { "Unknown", "SolarSystem", "Planet", "Animal", "Flora", "Mineral", "Sector" })]
         public GcDiscoveryWorth[] DiscoveryWorth;
 
         [NMS(Size = 0x80)]
@@ -34,19 +34,19 @@ namespace MBINCompiler.Models.Structs
 
         public GcRealityIconTable Icons;
 
-        [NMSAttribute(Size = 6, EnumValue = new string[6] { "None", "NoOxygen", "ExtremeHeat", "ExtremeCold", "ToxicGas", "Radiation" })]
+        [NMS(Size = 6, EnumValue = new string[6] { "None", "NoOxygen", "ExtremeHeat", "ExtremeCold", "ToxicGas", "Radiation" })]
         public Colour[] HazardColours;
 
-        [NMSAttribute(Size = 3, EnumValue = new string[3] { "Common", "Uncommon", "Rare" })]
+        [NMS(Size = 3, EnumValue = new string[3] { "Common", "Uncommon", "Rare" })]
         public Colour[] RarityColours;
 
-        [NMSAttribute(Size = 5, EnumValue = new string[5] { "Commodity", "Technology", "Fuel", "Tradeable", "Special" })]
+        [NMS(Size = 5, EnumValue = new string[5] { "Commodity", "Technology", "Fuel", "Tradeable", "Special" })]
         public Colour[] SubstanceCategoryColours;
 
-        [NMSAttribute(Size = 5, EnumValue = new string[5] { "Commodity", "Technology", "Fuel", "Tradeable", "Special" })]
+        [NMS(Size = 5, EnumValue = new string[5] { "Commodity", "Technology", "Fuel", "Tradeable", "Special" })]
         public TkTextureResource[] SubstanceChargeIcons;
 
-        [NMSAttribute(Size = 70, EnumValue = new string[70]
+        [NMS(Size = 70, EnumValue = new string[70]
             {
                 "Weapon_Laser", "Weapon_Laser_Damage", "Weapon_Laser_Mining_Damage", "Weapon_Laser_Mining_Speed", "Weapon_Laser_HeatTime", "Weapon_Laser_Bounce", "Weapon_Laser_ReloadTime", "Weapon_Laser_Recoil",
                 "Weapon_Projectile", "Weapon_Projectile_Damage", "Weapon_Projectile_Mining_Damage", "Weapon_Projectile_Range", "Weapon_Projectile_Rate", "Weapon_Projectile_ClipSize", "Weapon_Projectile_ReloadTime", "Weapon_Projectile_Recoil",
@@ -60,10 +60,10 @@ namespace MBINCompiler.Models.Structs
             })]
         public TkTextureResource[] StatCategoryIcons;
 
-        [NMSAttribute(Ignore = true)]
+        [NMS(Ignore = true)]
         public int EmptyNode2;
 
-        [NMSAttribute(Size = 3, EnumValue = new string[3] { "Suit", "Weapon", "Ship" })]
+        [NMS(Size = 3, EnumValue = new string[3] { "Suit", "Weapon", "Ship" })]
         public GcStats[] Stats;
 
         public GcTradeSettings TradeSettings;
@@ -72,7 +72,7 @@ namespace MBINCompiler.Models.Structs
 
         public List<NMSString0x10> NeverSellableItems;
 
-        [NMSAttribute(Size = 5, EnumValue = new string[5] { "Commodity", "Technology", "Fuel", "Tradeable", "Special" })]
+        [NMS(Size = 5, EnumValue = new string[5] { "Commodity", "Technology", "Fuel", "Tradeable", "Special" })]
         public float[] NormalizedPriceLimits;
     }
 }

--- a/MBINCompiler/Models/Structs/GcResourceElement.cs
+++ b/MBINCompiler/Models/Structs/GcResourceElement.cs
@@ -6,7 +6,7 @@ namespace MBINCompiler.Models.Structs
     {
         [NMS(Size = 0x80)]
         public string Filename;
-        [NMSAttribute(Ignore = true)]
+        [NMS(Ignore = true)]
         public long EmptyNode1;
         public GcSeed GenerationSeed;
         [NMS(Size = 0x200)]

--- a/MBINCompiler/Models/Structs/GcResourceElement.cs
+++ b/MBINCompiler/Models/Structs/GcResourceElement.cs
@@ -4,12 +4,12 @@ namespace MBINCompiler.Models.Structs
 {
     public class GcResourceElement : NMSTemplate
     {
-        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 0x80)]
+        [NMS(Size = 0x80)]
         public string Filename;
         [NMSAttribute(Ignore = true)]
         public long EmptyNode1;
         public GcSeed GenerationSeed;
-        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 0x200)]
+        [NMS(Size = 0x200)]
         public string AltId;
         public TkProceduralTextureChosenOptionList Texture;
     }

--- a/MBINCompiler/Models/Structs/GcResourceElement.cs
+++ b/MBINCompiler/Models/Structs/GcResourceElement.cs
@@ -1,6 +1,4 @@
-﻿using System.Runtime.InteropServices;
-
-namespace MBINCompiler.Models.Structs
+﻿namespace MBINCompiler.Models.Structs
 {
     public class GcResourceElement : NMSTemplate
     {

--- a/MBINCompiler/Models/Structs/GcRewardAction.cs
+++ b/MBINCompiler/Models/Structs/GcRewardAction.cs
@@ -4,7 +4,7 @@ namespace MBINCompiler.Models.Structs
 {
     public class GcRewardAction : NMSTemplate
     {
-        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 0x10)]
+        [NMS(Size = 0x10)]
         public string Reward;
     }
 }

--- a/MBINCompiler/Models/Structs/GcRewardAction.cs
+++ b/MBINCompiler/Models/Structs/GcRewardAction.cs
@@ -1,6 +1,4 @@
-﻿using System.Runtime.InteropServices;
-
-namespace MBINCompiler.Models.Structs
+﻿namespace MBINCompiler.Models.Structs
 {
     public class GcRewardAction : NMSTemplate
     {

--- a/MBINCompiler/Models/Structs/GcRewardDamage.cs
+++ b/MBINCompiler/Models/Structs/GcRewardDamage.cs
@@ -1,6 +1,4 @@
-﻿using System.Runtime.InteropServices;
-
-namespace MBINCompiler.Models.Structs
+﻿namespace MBINCompiler.Models.Structs
 {
     public class GcRewardDamage : NMSTemplate
     {

--- a/MBINCompiler/Models/Structs/GcRewardDamage.cs
+++ b/MBINCompiler/Models/Structs/GcRewardDamage.cs
@@ -4,7 +4,7 @@ namespace MBINCompiler.Models.Structs
 {
     public class GcRewardDamage : NMSTemplate
     {
-        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 0x10)]
+        [NMS(Size = 0x10)]
         public string PlayerDamage;
     }
 }

--- a/MBINCompiler/Models/Structs/GcRewardDestructTable.cs
+++ b/MBINCompiler/Models/Structs/GcRewardDestructTable.cs
@@ -2,7 +2,7 @@
 {
     public class GcRewardDestructTable : NMSTemplate
     {
-        [NMSAttribute(Size = 5)]
+        [NMS(Size = 5)]
         public GcRewardDestructRarities[] Categories;
     }
 }

--- a/MBINCompiler/Models/Structs/GcRewardShield.cs
+++ b/MBINCompiler/Models/Structs/GcRewardShield.cs
@@ -1,6 +1,4 @@
-﻿using System.Runtime.InteropServices;
-
-namespace MBINCompiler.Models.Structs
+﻿namespace MBINCompiler.Models.Structs
 {
     public class GcRewardShield : NMSTemplate
     {

--- a/MBINCompiler/Models/Structs/GcRewardSpecificProduct.cs
+++ b/MBINCompiler/Models/Structs/GcRewardSpecificProduct.cs
@@ -1,6 +1,4 @@
-﻿using System.Runtime.InteropServices;
-
-namespace MBINCompiler.Models.Structs
+﻿namespace MBINCompiler.Models.Structs
 {
     public class GcRewardSpecificProduct : NMSTemplate
     {

--- a/MBINCompiler/Models/Structs/GcRewardSpecificProduct.cs
+++ b/MBINCompiler/Models/Structs/GcRewardSpecificProduct.cs
@@ -4,7 +4,7 @@ namespace MBINCompiler.Models.Structs
 {
     public class GcRewardSpecificProduct : NMSTemplate
     {
-        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 0x10)]
+        [NMS(Size = 0x10)]
         public string Id;
         public int AmountMin;
         public int AmountMax;

--- a/MBINCompiler/Models/Structs/GcRewardSpecificProductRecipe.cs
+++ b/MBINCompiler/Models/Structs/GcRewardSpecificProductRecipe.cs
@@ -1,6 +1,4 @@
-﻿using System.Runtime.InteropServices;
-
-namespace MBINCompiler.Models.Structs
+﻿namespace MBINCompiler.Models.Structs
 {
     public class GcRewardSpecificProductRecipe : NMSTemplate
     {

--- a/MBINCompiler/Models/Structs/GcRewardSpecificProductRecipe.cs
+++ b/MBINCompiler/Models/Structs/GcRewardSpecificProductRecipe.cs
@@ -4,7 +4,7 @@ namespace MBINCompiler.Models.Structs
 {
     public class GcRewardSpecificProductRecipe : NMSTemplate
     {
-        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 0x10)]
+        [NMS(Size = 0x10)]
         public string Id;
     }
 }

--- a/MBINCompiler/Models/Structs/GcRewardSpecificTech.cs
+++ b/MBINCompiler/Models/Structs/GcRewardSpecificTech.cs
@@ -4,7 +4,7 @@ namespace MBINCompiler.Models.Structs
 {
     public class GcRewardSpecificTech : NMSTemplate
     {
-        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 0x10)]
+        [NMS(Size = 0x10)]
         public string TechId;
     }
 }

--- a/MBINCompiler/Models/Structs/GcRewardSpecificTech.cs
+++ b/MBINCompiler/Models/Structs/GcRewardSpecificTech.cs
@@ -1,6 +1,4 @@
-﻿using System.Runtime.InteropServices;
-
-namespace MBINCompiler.Models.Structs
+﻿namespace MBINCompiler.Models.Structs
 {
     public class GcRewardSpecificTech : NMSTemplate
     {

--- a/MBINCompiler/Models/Structs/GcRewardTableEntry.cs
+++ b/MBINCompiler/Models/Structs/GcRewardTableEntry.cs
@@ -4,7 +4,7 @@ namespace MBINCompiler.Models.Structs
 {
     public class GcRewardTableEntry : NMSTemplate
     {
-        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 0x10)]
+        [NMS(Size = 0x10)]
         public string Id;
         public GcRewardTableCategory Common; // This actually is a GcRewardTableCategory[3], values are GcRarity
         public GcRewardTableCategory Uncommon;

--- a/MBINCompiler/Models/Structs/GcRewardTableEntry.cs
+++ b/MBINCompiler/Models/Structs/GcRewardTableEntry.cs
@@ -1,6 +1,4 @@
-﻿using System.Runtime.InteropServices;
-
-namespace MBINCompiler.Models.Structs
+﻿namespace MBINCompiler.Models.Structs
 {
     public class GcRewardTableEntry : NMSTemplate
     {

--- a/MBINCompiler/Models/Structs/GcRewardTableItem.cs
+++ b/MBINCompiler/Models/Structs/GcRewardTableItem.cs
@@ -6,7 +6,7 @@ namespace MBINCompiler.Models.Structs
     {
         public float PercentageChance;
         public NMSTemplate Reward; // Generic
-        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 0x40)]
+        [NMS(Size = 0x40)]
         public string LabelID;
     }
 }

--- a/MBINCompiler/Models/Structs/GcRewardTableItem.cs
+++ b/MBINCompiler/Models/Structs/GcRewardTableItem.cs
@@ -1,6 +1,4 @@
-﻿using System.Runtime.InteropServices;
-
-namespace MBINCompiler.Models.Structs
+﻿namespace MBINCompiler.Models.Structs
 {
     public class GcRewardTableItem : NMSTemplate
     {

--- a/MBINCompiler/Models/Structs/GcRewardTableItemList.cs
+++ b/MBINCompiler/Models/Structs/GcRewardTableItemList.cs
@@ -1,5 +1,4 @@
 ﻿using System.Collections.Generic;
-using System.Runtime.InteropServices;
 
 namespace MBINCompiler.Models.Structs
 {

--- a/MBINCompiler/Models/Structs/GcRewardTableItemList.cs
+++ b/MBINCompiler/Models/Structs/GcRewardTableItemList.cs
@@ -6,7 +6,7 @@ namespace MBINCompiler.Models.Structs
     public class GcRewardTableItemList : NMSTemplate
     {
         public bool EntitlementLinked;
-        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 0x20)]
+        [NMS(Size = 0x20)]
         public string EntitlementId;
         public GcRewardTableChoice RewardChoice;
         public List<GcRewardTableItem> List;

--- a/MBINCompiler/Models/Structs/GcRewardTechRecipe.cs
+++ b/MBINCompiler/Models/Structs/GcRewardTechRecipe.cs
@@ -5,7 +5,7 @@ namespace MBINCompiler.Models.Structs
     public class GcRewardTechRecipe : NMSTemplate
     {
         public GcTechnologyCategory Category;
-        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 0x10)]
+        [NMS(Size = 0x10)]
         public string RewardGroup;
     }
 }

--- a/MBINCompiler/Models/Structs/GcRewardTechRecipe.cs
+++ b/MBINCompiler/Models/Structs/GcRewardTechRecipe.cs
@@ -1,6 +1,4 @@
-﻿using System.Runtime.InteropServices;
-
-namespace MBINCompiler.Models.Structs
+﻿namespace MBINCompiler.Models.Structs
 {
     public class GcRewardTechRecipe : NMSTemplate
     {

--- a/MBINCompiler/Models/Structs/GcSavedInteractionRaceData.cs
+++ b/MBINCompiler/Models/Structs/GcSavedInteractionRaceData.cs
@@ -1,6 +1,4 @@
-﻿using System.Collections.Generic;
-
-namespace MBINCompiler.Models.Structs
+﻿namespace MBINCompiler.Models.Structs
 {
     public class GcSavedInteractionRaceData : NMSTemplate // 0x18 bytes
     {

--- a/MBINCompiler/Models/Structs/GcScannableComponentData.cs
+++ b/MBINCompiler/Models/Structs/GcScannableComponentData.cs
@@ -1,6 +1,4 @@
-﻿using System.Collections.Generic;
-
-namespace MBINCompiler.Models.Structs
+﻿namespace MBINCompiler.Models.Structs
 {
     public class GcScannableComponentData : NMSTemplate
     {

--- a/MBINCompiler/Models/Structs/GcScannerIconTypes.cs
+++ b/MBINCompiler/Models/Structs/GcScannerIconTypes.cs
@@ -1,6 +1,4 @@
-﻿using System.Collections.Generic;
-
-namespace MBINCompiler.Models.Structs
+﻿namespace MBINCompiler.Models.Structs
 {
     public class GcScannerIconTypes : NMSTemplate
     {

--- a/MBINCompiler/Models/Structs/GcScannerIcons.cs
+++ b/MBINCompiler/Models/Structs/GcScannerIcons.cs
@@ -1,10 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace MBINCompiler.Models.Structs
+﻿namespace MBINCompiler.Models.Structs
 {
     public class GcScannerIcons : NMSTemplate
     {

--- a/MBINCompiler/Models/Structs/GcScareCreaturesAction.cs
+++ b/MBINCompiler/Models/Structs/GcScareCreaturesAction.cs
@@ -1,6 +1,4 @@
-﻿using System.Collections.Generic;
-
-namespace MBINCompiler.Models.Structs
+﻿namespace MBINCompiler.Models.Structs
 {
     public class GcScareCreaturesAction : NMSTemplate
     {

--- a/MBINCompiler/Models/Structs/GcSceneSettings.cs
+++ b/MBINCompiler/Models/Structs/GcSceneSettings.cs
@@ -5,38 +5,37 @@ namespace MBINCompiler.Models.Structs
 {
     public class GcSceneSettings : NMSTemplate
     {
-        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 0x80)]
+        [NMS(Size = 0x80)]
         /* 0x000 */ public string NextSettingFile;
 
-        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 0x80)]
+        [NMS(Size = 0x80)]
         /* 0x080 */ public string SceneFile;
 
         /* 0x100 */ public List<NMSString0x80> PlanetSceneFiles;
 
-        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 0x80)]
+        [NMS(Size = 0x80)]
         /* 0x110 */ public string SolarSystemFile;
 
-        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 0x80)]
+        [NMS(Size = 0x80)]
         /* 0x190 */ public string PlanetFiles1;
 
-        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 0x80)]
+        [NMS(Size = 0x80)]
         /* 0x210 */ public string PlanetFiles2;
 
-        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 0x80)]
+        [NMS(Size = 0x80)]
         /* 0x290 */ public string PlanetFiles3;
 
-        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 0x80)]
+        [NMS(Size = 0x80)]
         /* 0x310 */ public string PlanetFiles4;
 
-        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 0x80)]
+        [NMS(Size = 0x80)]
         /* 0x390 */ public string PlanetFiles5;
 
         /* 0x410 */ public List<NMSString0x80> ShipPreloadFiles;
         /* 0x420 */ public bool SpawnShip;
         /* 0x421 */ public bool SpawnInsideShip;
 
-        [MarshalAs(UnmanagedType.ByValArray, SizeConst = 0xE)]
-        [NMSAttribute(Ignore = true)]
+        [NMS(Size = 0xE, Ignore = true)]
         /* 0x422 */ public byte[] Padding422;
 
         /* 0x430 */ public GcPlayerSpawnStateData PlayerState;
@@ -44,7 +43,7 @@ namespace MBINCompiler.Models.Structs
         /* 0x480 */ public List<NMSTemplate> Events;
         /* 0x490 */ public List<NMSTemplate> PostWarpEvents;
 
-        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 0x10)]
+        [NMS(Size = 0x10)]
         /* 0x4A0 */ public string SpawnerOptionId;
     }
 }

--- a/MBINCompiler/Models/Structs/GcSceneSettings.cs
+++ b/MBINCompiler/Models/Structs/GcSceneSettings.cs
@@ -1,5 +1,4 @@
 ﻿using System.Collections.Generic;
-using System.Runtime.InteropServices;
 
 namespace MBINCompiler.Models.Structs
 {

--- a/MBINCompiler/Models/Structs/GcShieldComponentData.cs
+++ b/MBINCompiler/Models/Structs/GcShieldComponentData.cs
@@ -1,6 +1,4 @@
-﻿using System.Collections.Generic;
-
-namespace MBINCompiler.Models.Structs
+﻿namespace MBINCompiler.Models.Structs
 {
     public class GcShieldComponentData : NMSTemplate
     {

--- a/MBINCompiler/Models/Structs/GcShootableComponentData.cs
+++ b/MBINCompiler/Models/Structs/GcShootableComponentData.cs
@@ -1,6 +1,4 @@
-﻿using System.Collections.Generic;
-
-namespace MBINCompiler.Models.Structs
+﻿namespace MBINCompiler.Models.Structs
 {
     public class GcShootableComponentData : NMSTemplate
     {

--- a/MBINCompiler/Models/Structs/GcSimpleInteractionComponentData.cs
+++ b/MBINCompiler/Models/Structs/GcSimpleInteractionComponentData.cs
@@ -1,6 +1,4 @@
-﻿using System.Collections.Generic;
-
-namespace MBINCompiler.Models.Structs
+﻿namespace MBINCompiler.Models.Structs
 {
     public class GcSimpleInteractionComponentData : NMSTemplate
     {

--- a/MBINCompiler/Models/Structs/GcSizeIndicator.cs
+++ b/MBINCompiler/Models/Structs/GcSizeIndicator.cs
@@ -1,6 +1,4 @@
-﻿using System.Collections.Generic;
-
-namespace MBINCompiler.Models.Structs
+﻿namespace MBINCompiler.Models.Structs
 {
     public class GcSizeIndicator : NMSTemplate
     {

--- a/MBINCompiler/Models/Structs/GcSolarSystemData.cs
+++ b/MBINCompiler/Models/Structs/GcSolarSystemData.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using System.Collections.Generic;
 
 namespace MBINCompiler.Models.Structs
 {

--- a/MBINCompiler/Models/Structs/GcSpaceshipClasses.cs
+++ b/MBINCompiler/Models/Structs/GcSpaceshipClasses.cs
@@ -1,6 +1,4 @@
-﻿using System.Collections.Generic;
-
-namespace MBINCompiler.Models.Structs
+﻿namespace MBINCompiler.Models.Structs
 {
     public class GcSpaceshipClasses : NMSTemplate
     {

--- a/MBINCompiler/Models/Structs/GcSpaceshipComponentData.cs
+++ b/MBINCompiler/Models/Structs/GcSpaceshipComponentData.cs
@@ -1,6 +1,4 @@
-﻿using System.Collections.Generic;
-
-namespace MBINCompiler.Models.Structs
+﻿namespace MBINCompiler.Models.Structs
 {
     public class GcSpaceshipComponentData : NMSTemplate
     {

--- a/MBINCompiler/Models/Structs/GcSpawnAction.cs
+++ b/MBINCompiler/Models/Structs/GcSpawnAction.cs
@@ -1,6 +1,4 @@
-﻿using System.Collections.Generic;
-
-namespace MBINCompiler.Models.Structs
+﻿namespace MBINCompiler.Models.Structs
 {
     public class GcSpawnAction : NMSTemplate
     {

--- a/MBINCompiler/Models/Structs/GcSpawnComponentOption.cs
+++ b/MBINCompiler/Models/Structs/GcSpawnComponentOption.cs
@@ -1,6 +1,4 @@
-﻿using System.Collections.Generic;
-
-namespace MBINCompiler.Models.Structs
+﻿namespace MBINCompiler.Models.Structs
 {
     public class GcSpawnComponentOption : NMSTemplate // 0x2C8 bytes
     {

--- a/MBINCompiler/Models/Structs/GcSpawnDensity.cs
+++ b/MBINCompiler/Models/Structs/GcSpawnDensity.cs
@@ -4,7 +4,7 @@ namespace MBINCompiler.Models.Structs
 {
     public class GcSpawnDensity : NMSTemplate
     {
-        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 0x10)]
+        [NMS(Size = 0x10)]
         public string Name;
         public bool Active;
         public int CoverageType;

--- a/MBINCompiler/Models/Structs/GcSpawnDensity.cs
+++ b/MBINCompiler/Models/Structs/GcSpawnDensity.cs
@@ -1,6 +1,4 @@
-﻿using System.Runtime.InteropServices;
-
-namespace MBINCompiler.Models.Structs
+﻿namespace MBINCompiler.Models.Structs
 {
     public class GcSpawnDensity : NMSTemplate
     {

--- a/MBINCompiler/Models/Structs/GcStatDefinition.cs
+++ b/MBINCompiler/Models/Structs/GcStatDefinition.cs
@@ -9,7 +9,7 @@ namespace MBINCompiler.Models.Structs
         public GcStatDisplayType DisplayType;
         public GcStatValueData DefaultValue;
 
-        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 0x10)]
+        [NMS(Size = 0x10)]
         public string Id;
     }
 }

--- a/MBINCompiler/Models/Structs/GcStatDefinition.cs
+++ b/MBINCompiler/Models/Structs/GcStatDefinition.cs
@@ -1,6 +1,4 @@
-﻿using System.Runtime.InteropServices;
-
-namespace MBINCompiler.Models.Structs
+﻿namespace MBINCompiler.Models.Structs
 {
     public class GcStatDefinition : NMSTemplate
     {

--- a/MBINCompiler/Models/Structs/GcStatGroupData.cs
+++ b/MBINCompiler/Models/Structs/GcStatGroupData.cs
@@ -5,7 +5,7 @@ namespace MBINCompiler.Models.Structs
 {
     public class GcStatGroupData : NMSTemplate
     {
-        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 0x10)]
+        [NMS(Size = 0x10)]
         public string GroupName;
         public List<NMSString0x10> TrackedStats;
     }

--- a/MBINCompiler/Models/Structs/GcStatGroupData.cs
+++ b/MBINCompiler/Models/Structs/GcStatGroupData.cs
@@ -1,5 +1,4 @@
 ﻿using System.Collections.Generic;
-using System.Runtime.InteropServices;
 
 namespace MBINCompiler.Models.Structs
 {

--- a/MBINCompiler/Models/Structs/GcStateTimeEvent.cs
+++ b/MBINCompiler/Models/Structs/GcStateTimeEvent.cs
@@ -1,6 +1,4 @@
-﻿using System.Collections.Generic;
-
-namespace MBINCompiler.Models.Structs
+﻿namespace MBINCompiler.Models.Structs
 {
     public class GcStateTimeEvent : NMSTemplate
     {

--- a/MBINCompiler/Models/Structs/GcStats.cs
+++ b/MBINCompiler/Models/Structs/GcStats.cs
@@ -2,7 +2,7 @@
 {
     public class GcStats : NMSTemplate
     {
-        [NMSAttribute(Size = 4)]
+        [NMS(Size = 4)]
         public GcStatsGroup[] Stats;
     }
 }

--- a/MBINCompiler/Models/Structs/GcStatsEntry.cs
+++ b/MBINCompiler/Models/Structs/GcStatsEntry.cs
@@ -8,7 +8,7 @@
         public float RangeMax;
         public bool LessIsBetter;
 
-        [NMSAttribute(Ignore = true)]
+        [NMS(Ignore = true)]
         public int EmptyNode1;
     }
 }

--- a/MBINCompiler/Models/Structs/GcStatsGroup.cs
+++ b/MBINCompiler/Models/Structs/GcStatsGroup.cs
@@ -1,5 +1,4 @@
 ﻿using System.Collections.Generic;
-using System.Runtime.InteropServices;
 
 namespace MBINCompiler.Models.Structs
 {

--- a/MBINCompiler/Models/Structs/GcStatsGroup.cs
+++ b/MBINCompiler/Models/Structs/GcStatsGroup.cs
@@ -5,7 +5,7 @@ namespace MBINCompiler.Models.Structs
 {
     public class GcStatsGroup : NMSTemplate
     {
-        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 0x10)]
+        [NMS(Size = 0x10)]
         public string Id;
 
         public TkTextureResource Icon;

--- a/MBINCompiler/Models/Structs/GcSubstanceAmount.cs
+++ b/MBINCompiler/Models/Structs/GcSubstanceAmount.cs
@@ -1,6 +1,4 @@
-﻿using System.Collections.Generic;
-
-namespace MBINCompiler.Models.Structs
+﻿namespace MBINCompiler.Models.Structs
 {
     public class GcSubstanceAmount : NMSTemplate // 0x20 bytes
     {

--- a/MBINCompiler/Models/Structs/GcSubstanceData.cs
+++ b/MBINCompiler/Models/Structs/GcSubstanceData.cs
@@ -1,7 +1,4 @@
-﻿using System.Runtime.InteropServices;
-using System.Collections.Generic;
-
-namespace MBINCompiler.Models.Structs
+﻿namespace MBINCompiler.Models.Structs
 {
     public class GcSubstanceData : NMSTemplate
     {

--- a/MBINCompiler/Models/Structs/GcSubstanceData.cs
+++ b/MBINCompiler/Models/Structs/GcSubstanceData.cs
@@ -5,13 +5,13 @@ namespace MBINCompiler.Models.Structs
 {
     public class GcSubstanceData : NMSTemplate
     {
-        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 0x20)]
+        [NMS(Size = 0x20)]
         public string Name;
-        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 0x20)]
+        [NMS(Size = 0x20)]
         public string NameLower;
-        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 0x10)]
+        [NMS(Size = 0x10)]
         public string Id;
-        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 0x20)]
+        [NMS(Size = 0x20)]
         public string Symbol;
         public TkTextureResource Icon;
         public TkModelResource Debris;

--- a/MBINCompiler/Models/Structs/GcTechnology.cs
+++ b/MBINCompiler/Models/Structs/GcTechnology.cs
@@ -5,27 +5,26 @@ namespace MBINCompiler.Models.Structs
 {
     public class GcTechnology : NMSTemplate
     {
-        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 0x10)]
+        [NMS(Size = 0x10)]
         /* 0x000 */ public string ID; // 0x10
 
-        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 0x80)]
+        [NMS(Size = 0x80)]
         /* 0x010 */ public string Name; // 0x80
 
-        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 0x80)]
+        [NMS(Size = 0x80)]
         /* 0x090 */ public string NameLower; // 0x80
 
         /* 0x110 */ public VariableSizeString Subtitle;
         /* 0x120 */ public VariableSizeString Description;
         /* 0x130 */ public bool Teach;
 
-        [MarshalAs(UnmanagedType.ByValArray, SizeConst = 0x7)]
-        [NMSAttribute(Ignore = true)]
+        [NMS(Size = 0x7, Ignore = true)]
         /* 0x131 */ public byte[] Padding131;
 
-        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 0x20)]
+        [NMS(Size = 0x20)]
         /* 0x138 */ public string HintStart;
 
-        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 0x20)]
+        [NMS(Size = 0x20)]
         /* 0x158 */ public string HintEnd;
 
         /* 0x178 */ public TkTextureResource Icon;
@@ -48,7 +47,7 @@ namespace MBINCompiler.Models.Structs
         /* 0x240 */ public List<GcTechnologyRequirement> Requirements;
         /* 0x250 */ public List<GcStatsBonus> StatBonuses;
 
-        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 0x10)]
+        [NMS(Size = 0x10)]
         /* 0x260 */ public string RequiredTech;
 
         /* 0x270 */ public float RequiredLevel; // todo: is this correct?
@@ -56,7 +55,7 @@ namespace MBINCompiler.Models.Structs
         /* 0x280 */ public Colour UpgradeColour;
         /* 0x290 */ public Colour LinkColour;
 
-        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 0x10)]
+        [NMS(Size = 0x10)]
         /* 0x2A0 */ public string RewardGroup;
     }
 }

--- a/MBINCompiler/Models/Structs/GcTechnology.cs
+++ b/MBINCompiler/Models/Structs/GcTechnology.cs
@@ -1,5 +1,4 @@
 ﻿using System.Collections.Generic;
-using System.Runtime.InteropServices;
 
 namespace MBINCompiler.Models.Structs
 {

--- a/MBINCompiler/Models/Structs/GcTechnologyRequirement.cs
+++ b/MBINCompiler/Models/Structs/GcTechnologyRequirement.cs
@@ -1,6 +1,4 @@
-﻿using System.Runtime.InteropServices;
-
-namespace MBINCompiler.Models.Structs
+﻿namespace MBINCompiler.Models.Structs
 {
     public class GcTechnologyRequirement : NMSTemplate
     {

--- a/MBINCompiler/Models/Structs/GcTechnologyRequirement.cs
+++ b/MBINCompiler/Models/Structs/GcTechnologyRequirement.cs
@@ -4,7 +4,7 @@ namespace MBINCompiler.Models.Structs
 {
     public class GcTechnologyRequirement : NMSTemplate
     {
-        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 0x10)]
+        [NMS(Size = 0x10)]
         public string ID;
 
         public GcInventoryType InventoryType;

--- a/MBINCompiler/Models/Structs/GcTestMetadata.cs
+++ b/MBINCompiler/Models/Structs/GcTestMetadata.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using System.Collections.Generic;
 
 namespace MBINCompiler.Models.Structs
 {

--- a/MBINCompiler/Models/Structs/GcTradeData.cs
+++ b/MBINCompiler/Models/Structs/GcTradeData.cs
@@ -1,5 +1,4 @@
 ﻿using System.Collections.Generic;
-using System.Runtime.InteropServices;
 
 namespace MBINCompiler.Models.Structs
 {

--- a/MBINCompiler/Models/Structs/GcTradeSettings.cs
+++ b/MBINCompiler/Models/Structs/GcTradeSettings.cs
@@ -1,7 +1,4 @@
-﻿using System.Collections.Generic;
-using System.Runtime.InteropServices;
-
-namespace MBINCompiler.Models.Structs
+﻿namespace MBINCompiler.Models.Structs
 {
     public class GcTradeSettings : NMSTemplate
     {

--- a/MBINCompiler/Models/Structs/GcTurretComponentData.cs
+++ b/MBINCompiler/Models/Structs/GcTurretComponentData.cs
@@ -1,6 +1,4 @@
-﻿using System.Collections.Generic;
-
-namespace MBINCompiler.Models.Structs
+﻿namespace MBINCompiler.Models.Structs
 {
     public class GcTurretComponentData : NMSTemplate
     {

--- a/MBINCompiler/Models/Structs/GcUserSettingsData.cs
+++ b/MBINCompiler/Models/Structs/GcUserSettingsData.cs
@@ -1,7 +1,4 @@
-﻿using System.Collections.Generic;
-using System.Runtime.InteropServices;
-
-namespace MBINCompiler.Models.Structs
+﻿namespace MBINCompiler.Models.Structs
 {
     public class GcUserSettingsData : NMSTemplate
     {

--- a/MBINCompiler/Models/Structs/GcWarpAction.cs
+++ b/MBINCompiler/Models/Structs/GcWarpAction.cs
@@ -1,6 +1,4 @@
-﻿using System.Collections.Generic;
-
-namespace MBINCompiler.Models.Structs
+﻿namespace MBINCompiler.Models.Structs
 {
     public class GcWarpAction : NMSTemplate
     {

--- a/MBINCompiler/Models/Structs/GcWaypointComponentData.cs
+++ b/MBINCompiler/Models/Structs/GcWaypointComponentData.cs
@@ -1,6 +1,4 @@
-﻿using System.Collections.Generic;
-
-namespace MBINCompiler.Models.Structs
+﻿namespace MBINCompiler.Models.Structs
 {
     public class GcWaypointComponentData : NMSTemplate
     {

--- a/MBINCompiler/Models/Structs/GcWeatherProperties.cs
+++ b/MBINCompiler/Models/Structs/GcWeatherProperties.cs
@@ -5,7 +5,7 @@ namespace MBINCompiler.Models.Structs
 {
     public class GcWeatherProperties : NMSTemplate
     {
-        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 0x10)]
+        [NMS(Size = 0x10)]
         public string Name;
 
         public GcFogProperties Fog;

--- a/MBINCompiler/Models/Structs/GcWeatherProperties.cs
+++ b/MBINCompiler/Models/Structs/GcWeatherProperties.cs
@@ -1,5 +1,4 @@
 ﻿using System.Collections.Generic;
-using System.Runtime.InteropServices;
 
 namespace MBINCompiler.Models.Structs
 {

--- a/MBINCompiler/Models/Structs/MBINCompilerTestTemplate.cs
+++ b/MBINCompiler/Models/Structs/MBINCompilerTestTemplate.cs
@@ -14,7 +14,7 @@ namespace MBINCompiler.Models.Structs
         public float TestFloat;
         public int TestEnumYes;
         public int TestEnumNo;
-        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 0x10)]
+        [NMS(Size = 0x10)]
         public string TestString;
         public VariableSizeString TestDynamicString;
         public List<NMSString0x80> Test0x80ByteStringList;

--- a/MBINCompiler/Models/Structs/MBINCompilerTestTemplate.cs
+++ b/MBINCompiler/Models/Structs/MBINCompilerTestTemplate.cs
@@ -1,5 +1,4 @@
 ﻿using System.Collections.Generic;
-using System.Runtime.InteropServices;
 
 namespace MBINCompiler.Models.Structs
 {

--- a/MBINCompiler/Models/Structs/NMSBool.cs
+++ b/MBINCompiler/Models/Structs/NMSBool.cs
@@ -1,6 +1,4 @@
-﻿using System.Runtime.InteropServices;
-
-namespace MBINCompiler.Models.Structs
+﻿namespace MBINCompiler.Models.Structs
 {
     public class NMSBool : NMSTemplate
     {

--- a/MBINCompiler/Models/Structs/NMSFloat.cs
+++ b/MBINCompiler/Models/Structs/NMSFloat.cs
@@ -1,6 +1,4 @@
-﻿using System.Runtime.InteropServices;
-
-namespace MBINCompiler.Models.Structs
+﻿namespace MBINCompiler.Models.Structs
 {
     public class NMSFloat : NMSTemplate
     {

--- a/MBINCompiler/Models/Structs/NMSString0x10.cs
+++ b/MBINCompiler/Models/Structs/NMSString0x10.cs
@@ -4,7 +4,7 @@ namespace MBINCompiler.Models.Structs
 {
     public class NMSString0x10 : NMSTemplate
     {
-        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 0x10)]
+        [NMS(Size = 0x10)]
         public string Value;
     }
 }

--- a/MBINCompiler/Models/Structs/NMSString0x10.cs
+++ b/MBINCompiler/Models/Structs/NMSString0x10.cs
@@ -1,6 +1,4 @@
-﻿using System.Runtime.InteropServices;
-
-namespace MBINCompiler.Models.Structs
+﻿namespace MBINCompiler.Models.Structs
 {
     public class NMSString0x10 : NMSTemplate
     {

--- a/MBINCompiler/Models/Structs/NMSString0x100.cs
+++ b/MBINCompiler/Models/Structs/NMSString0x100.cs
@@ -1,6 +1,4 @@
-﻿using System.Runtime.InteropServices;
-
-namespace MBINCompiler.Models.Structs
+﻿namespace MBINCompiler.Models.Structs
 {
     // todo: maybe get rid of this and just read strings directly into the list, if all strings are the same size?
     public class NMSString0x100 : NMSTemplate

--- a/MBINCompiler/Models/Structs/NMSString0x100.cs
+++ b/MBINCompiler/Models/Structs/NMSString0x100.cs
@@ -5,7 +5,7 @@ namespace MBINCompiler.Models.Structs
     // todo: maybe get rid of this and just read strings directly into the list, if all strings are the same size?
     public class NMSString0x100 : NMSTemplate
     {
-        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 0x100)]
+        [NMS(Size = 0x100)]
         public string Value;
     }
 }

--- a/MBINCompiler/Models/Structs/NMSString0x20.cs
+++ b/MBINCompiler/Models/Structs/NMSString0x20.cs
@@ -1,6 +1,4 @@
-﻿using System.Runtime.InteropServices;
-
-namespace MBINCompiler.Models.Structs
+﻿namespace MBINCompiler.Models.Structs
 {
     public class NMSString0x20 : NMSTemplate
     {

--- a/MBINCompiler/Models/Structs/NMSString0x20.cs
+++ b/MBINCompiler/Models/Structs/NMSString0x20.cs
@@ -4,7 +4,7 @@ namespace MBINCompiler.Models.Structs
 {
     public class NMSString0x20 : NMSTemplate
     {
-        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 0x20)]
+        [NMS(Size = 0x20)]
         public string Value;
     }
 }

--- a/MBINCompiler/Models/Structs/NMSString0x80.cs
+++ b/MBINCompiler/Models/Structs/NMSString0x80.cs
@@ -5,7 +5,7 @@ namespace MBINCompiler.Models.Structs
     // todo: maybe get rid of this and just read strings directly into the list, if all strings are the same size?
     public class NMSString0x80 : NMSTemplate
     {
-        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 0x80)]
+        [NMS(Size = 0x80)]
         public string Value;
     }
 }

--- a/MBINCompiler/Models/Structs/NMSString0x80.cs
+++ b/MBINCompiler/Models/Structs/NMSString0x80.cs
@@ -1,6 +1,4 @@
-﻿using System.Runtime.InteropServices;
-
-namespace MBINCompiler.Models.Structs
+﻿namespace MBINCompiler.Models.Structs
 {
     // todo: maybe get rid of this and just read strings directly into the list, if all strings are the same size?
     public class NMSString0x80 : NMSTemplate

--- a/MBINCompiler/Models/Structs/TkAnimPoseCorrelationData.cs
+++ b/MBINCompiler/Models/Structs/TkAnimPoseCorrelationData.cs
@@ -1,6 +1,4 @@
-﻿using System.Collections.Generic;
-
-namespace MBINCompiler.Models.Structs
+﻿namespace MBINCompiler.Models.Structs
 {
     public class TkAnimPoseCorrelationData : NMSTemplate // 0x28 bytes
     {

--- a/MBINCompiler/Models/Structs/TkAnimPoseData.cs
+++ b/MBINCompiler/Models/Structs/TkAnimPoseData.cs
@@ -1,6 +1,4 @@
-﻿using System.Collections.Generic;
-
-namespace MBINCompiler.Models.Structs
+﻿namespace MBINCompiler.Models.Structs
 {
     public class TkAnimPoseData : NMSTemplate // 0x18 bytes
     {

--- a/MBINCompiler/Models/Structs/TkAnimPoseExampleElement.cs
+++ b/MBINCompiler/Models/Structs/TkAnimPoseExampleElement.cs
@@ -1,6 +1,4 @@
-﻿using System.Collections.Generic;
-
-namespace MBINCompiler.Models.Structs
+﻿namespace MBINCompiler.Models.Structs
 {
     public class TkAnimPoseExampleElement : NMSTemplate // 0x18 bytes
     {

--- a/MBINCompiler/Models/Structs/TkAudioAnimTrigger.cs
+++ b/MBINCompiler/Models/Structs/TkAudioAnimTrigger.cs
@@ -1,6 +1,4 @@
-﻿using System.Collections.Generic;
-
-namespace MBINCompiler.Models.Structs
+﻿namespace MBINCompiler.Models.Structs
 {
     public class TkAudioAnimTrigger : NMSTemplate // 0x98 bytes
     {

--- a/MBINCompiler/Models/Structs/TkButtonPathMapping.cs
+++ b/MBINCompiler/Models/Structs/TkButtonPathMapping.cs
@@ -4,9 +4,9 @@ namespace MBINCompiler.Models.Structs
 {
     public class TkButtonPathMapping : NMSTemplate
     {
-        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 0x10)]
+        [NMS(Size = 0x10)]
         public string Id;
-        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 0x80)]
+        [NMS(Size = 0x80)]
         public string Path;
     }
 }

--- a/MBINCompiler/Models/Structs/TkButtonPathMapping.cs
+++ b/MBINCompiler/Models/Structs/TkButtonPathMapping.cs
@@ -1,6 +1,4 @@
-﻿using System.Runtime.InteropServices;
-
-namespace MBINCompiler.Models.Structs
+﻿namespace MBINCompiler.Models.Structs
 {
     public class TkButtonPathMapping : NMSTemplate
     {

--- a/MBINCompiler/Models/Structs/TkCameraWanderData.cs
+++ b/MBINCompiler/Models/Structs/TkCameraWanderData.cs
@@ -1,6 +1,4 @@
-﻿using System.Collections.Generic;
-
-namespace MBINCompiler.Models.Structs
+﻿namespace MBINCompiler.Models.Structs
 {
     public class TkCameraWanderData : NMSTemplate
     {

--- a/MBINCompiler/Models/Structs/TkControllerButtonLookup.cs
+++ b/MBINCompiler/Models/Structs/TkControllerButtonLookup.cs
@@ -1,6 +1,4 @@
-﻿using System.Runtime.InteropServices;
-
-namespace MBINCompiler.Models.Structs
+﻿namespace MBINCompiler.Models.Structs
 {
     public class TkControllerButtonLookup : NMSTemplate
     {

--- a/MBINCompiler/Models/Structs/TkControllerButtonLookup.cs
+++ b/MBINCompiler/Models/Structs/TkControllerButtonLookup.cs
@@ -4,9 +4,9 @@ namespace MBINCompiler.Models.Structs
 {
     public class TkControllerButtonLookup : NMSTemplate
     {
-        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 0x10)]
+        [NMS(Size = 0x10)]
         public string Id;
-        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 0x80)]
+        [NMS(Size = 0x80)]
         public string ButtonImageLookupFilename;
     }
 }

--- a/MBINCompiler/Models/Structs/TkControllerSpecification.cs
+++ b/MBINCompiler/Models/Structs/TkControllerSpecification.cs
@@ -1,6 +1,4 @@
-﻿using System.Runtime.InteropServices;
-
-namespace MBINCompiler.Models.Structs
+﻿namespace MBINCompiler.Models.Structs
 {
     public class TkControllerSpecification : NMSTemplate
     {

--- a/MBINCompiler/Models/Structs/TkControllerSpecification.cs
+++ b/MBINCompiler/Models/Structs/TkControllerSpecification.cs
@@ -4,7 +4,7 @@ namespace MBINCompiler.Models.Structs
 {
     public class TkControllerSpecification : NMSTemplate
     {
-        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 0x10)]
+        [NMS(Size = 0x10)]
         public string Id;
         public TkButtonImageLookup ImageLookup;
     }

--- a/MBINCompiler/Models/Structs/TkEngineSettings.cs
+++ b/MBINCompiler/Models/Structs/TkEngineSettings.cs
@@ -1,10 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace MBINCompiler.Models.Structs
+﻿namespace MBINCompiler.Models.Structs
 {
     // doesn't seem to be used by the game, TkEngineSettings template isn't inside the exe
     // and the only file using this template (METADATA/ENGINE/TKENGINESETTINGS.MBIN) isn't referenced

--- a/MBINCompiler/Models/Structs/TkGraphicsSettings.cs
+++ b/MBINCompiler/Models/Structs/TkGraphicsSettings.cs
@@ -1,6 +1,4 @@
-﻿using System.Runtime.InteropServices;
-
-namespace MBINCompiler.Models.Structs
+﻿namespace MBINCompiler.Models.Structs
 {
     public class TkGraphicsSettings : NMSTemplate
     {

--- a/MBINCompiler/Models/Structs/TkGraphicsSettings.cs
+++ b/MBINCompiler/Models/Structs/TkGraphicsSettings.cs
@@ -43,8 +43,7 @@ namespace MBINCompiler.Models.Structs
         /* 0x38 */ public int Brightness;
         /* 0x3C */ public int MaxframeRate;
         /* 0x40 */ public bool NoHudMode;
-        [MarshalAs(UnmanagedType.ByValArray, SizeConst = 3)]
-        [NMSAttribute(Ignore = true)]
+        [NMS(Size = 3, Ignore = true)]
         /* 0x41 */ public byte[] Padding41;
     }
 }

--- a/MBINCompiler/Models/Structs/TkHeavyAirData.cs
+++ b/MBINCompiler/Models/Structs/TkHeavyAirData.cs
@@ -1,10 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace MBINCompiler.Models.Structs
+﻿namespace MBINCompiler.Models.Structs
 {
     public class TkHeavyAirData : NMSTemplate
     {

--- a/MBINCompiler/Models/Structs/TkInputEnum.cs
+++ b/MBINCompiler/Models/Structs/TkInputEnum.cs
@@ -1,10 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace MBINCompiler.Models.Structs
+﻿namespace MBINCompiler.Models.Structs
 {
     public class TkInputEnum : NMSTemplate
     {

--- a/MBINCompiler/Models/Structs/TkLanguageFontTableEntry.cs
+++ b/MBINCompiler/Models/Structs/TkLanguageFontTableEntry.cs
@@ -1,6 +1,4 @@
-﻿using System.Runtime.InteropServices;
-
-namespace MBINCompiler.Models.Structs
+﻿namespace MBINCompiler.Models.Structs
 {
     public class TkLanguageFontTableEntry : NMSTemplate
     {

--- a/MBINCompiler/Models/Structs/TkLanguageFontTableEntry.cs
+++ b/MBINCompiler/Models/Structs/TkLanguageFontTableEntry.cs
@@ -5,11 +5,11 @@ namespace MBINCompiler.Models.Structs
     public class TkLanguageFontTableEntry : NMSTemplate
     {
         public TkLanguages Language;
-        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 0x80)]
+        [NMS(Size = 0x80)]
         public string GameFont;
-        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 0x80)]
+        [NMS(Size = 0x80)]
         public string GameFont2;
-        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 0x80)]
+        [NMS(Size = 0x80)]
         public string ConsoleFont;
     }
 }

--- a/MBINCompiler/Models/Structs/TkLanguagesAllowedData.cs
+++ b/MBINCompiler/Models/Structs/TkLanguagesAllowedData.cs
@@ -8,8 +8,7 @@ namespace MBINCompiler.Models.Structs
         public List<TkLanguages> Allowed;
         public TkLanguages Language;
 
-        [MarshalAs(UnmanagedType.ByValArray, SizeConst = 4)]
-        [NMSAttribute(Ignore = true)]
+        [NMS(Size = 4, Ignore = true)]
         public byte[] Padding14;
     }
 }

--- a/MBINCompiler/Models/Structs/TkLanguagesAllowedData.cs
+++ b/MBINCompiler/Models/Structs/TkLanguagesAllowedData.cs
@@ -1,5 +1,4 @@
 ﻿using System.Collections.Generic;
-using System.Runtime.InteropServices;
 
 namespace MBINCompiler.Models.Structs
 {

--- a/MBINCompiler/Models/Structs/TkLocalisationEntry.cs
+++ b/MBINCompiler/Models/Structs/TkLocalisationEntry.cs
@@ -1,6 +1,4 @@
-﻿using System.Runtime.InteropServices;
-
-namespace MBINCompiler.Models.Structs
+﻿namespace MBINCompiler.Models.Structs
 {
     public class TkLocalisationEntry : NMSTemplate
     {

--- a/MBINCompiler/Models/Structs/TkLocalisationEntry.cs
+++ b/MBINCompiler/Models/Structs/TkLocalisationEntry.cs
@@ -4,7 +4,7 @@ namespace MBINCompiler.Models.Structs
 {
     public class TkLocalisationEntry : NMSTemplate
     {
-        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 0x20)]
+        [NMS(Size = 0x20)]
         public string Id;
 
         public VariableSizeString English;

--- a/MBINCompiler/Models/Structs/TkMaterialData.cs
+++ b/MBINCompiler/Models/Structs/TkMaterialData.cs
@@ -5,16 +5,16 @@ namespace MBINCompiler.Models.Structs
 {
     public class TkMaterialData : NMSTemplate
     {
-        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 0x80)]
+        [NMS(Size = 0x80)]
         public string Name;
-        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 0x20)]
+        [NMS(Size = 0x20)]
         public string Class;
         public int TransparencyLayerID;
         public bool CastShadow;
         public bool DisableZTest;
-        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 0x80)]
+        [NMS(Size = 0x80)]
         public string Link;
-        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 0x80)]
+        [NMS(Size = 0x80)]
         public string Shader;
         public List<TkMaterialFlags> Flags;
         public List<TkMaterialUniform> Uniforms;

--- a/MBINCompiler/Models/Structs/TkMaterialData.cs
+++ b/MBINCompiler/Models/Structs/TkMaterialData.cs
@@ -1,5 +1,4 @@
 ﻿using System.Collections.Generic;
-using System.Runtime.InteropServices;
 
 namespace MBINCompiler.Models.Structs
 {

--- a/MBINCompiler/Models/Structs/TkMaterialFlags.cs
+++ b/MBINCompiler/Models/Structs/TkMaterialFlags.cs
@@ -1,7 +1,4 @@
-﻿using System.Collections.Generic;
-using System.Runtime.InteropServices;
-
-namespace MBINCompiler.Models.Structs
+﻿namespace MBINCompiler.Models.Structs
 {
     public class TkMaterialFlags : NMSTemplate
     {

--- a/MBINCompiler/Models/Structs/TkMaterialSampler.cs
+++ b/MBINCompiler/Models/Structs/TkMaterialSampler.cs
@@ -1,7 +1,4 @@
-﻿using System.Collections.Generic;
-using System.Runtime.InteropServices;
-
-namespace MBINCompiler.Models.Structs
+﻿namespace MBINCompiler.Models.Structs
 {
     public class TkMaterialSampler : NMSTemplate
     {

--- a/MBINCompiler/Models/Structs/TkMaterialSampler.cs
+++ b/MBINCompiler/Models/Structs/TkMaterialSampler.cs
@@ -5,18 +5,17 @@ namespace MBINCompiler.Models.Structs
 {
     public class TkMaterialSampler : NMSTemplate
     {
-        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 0x20)]
+        [NMS(Size = 0x20)]
         public string Name;
-        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 0x80)]
+        [NMS(Size = 0x80)]
         public string Map;
         public bool IsCube;
         public bool UseCompression;
         public bool UseMipMaps;
         public bool IsSRGB;
-        [MarshalAs(UnmanagedType.ByValArray, SizeConst = 4)]
-        [NMSAttribute(Ignore = true)]
+        [NMS(Size = 4, Ignore = true)]
         public byte[] PaddingA4;
-        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 0x10)]
+        [NMS(Size = 0x10)]
         public string MaterialAlternativeId;
         public int TextureAddressMode;
         public string[] TextureAddressModeValues()
@@ -31,8 +30,7 @@ namespace MBINCompiler.Models.Structs
         }
 
         public int Anisotropy;
-        [MarshalAs(UnmanagedType.ByValArray, SizeConst = 4)]
-        [NMSAttribute(Ignore = true)]
+        [NMS(Size = 4, Ignore = true)]
         public byte[] PaddingC4;
     }
 }

--- a/MBINCompiler/Models/Structs/TkMaterialUniform.cs
+++ b/MBINCompiler/Models/Structs/TkMaterialUniform.cs
@@ -1,5 +1,4 @@
 ﻿using System.Collections.Generic;
-using System.Runtime.InteropServices;
 
 namespace MBINCompiler.Models.Structs
 {

--- a/MBINCompiler/Models/Structs/TkMaterialUniform.cs
+++ b/MBINCompiler/Models/Structs/TkMaterialUniform.cs
@@ -5,7 +5,7 @@ namespace MBINCompiler.Models.Structs
 {
     public class TkMaterialUniform : NMSTemplate
     {
-        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 0x20)]
+        [NMS(Size = 0x20)]
         public string Name;
         public Vector4f Values;
         public List<Vector4f> ExtendedValues;

--- a/MBINCompiler/Models/Structs/TkModelRendererCameraData.cs
+++ b/MBINCompiler/Models/Structs/TkModelRendererCameraData.cs
@@ -1,6 +1,4 @@
-﻿using System.Collections.Generic;
-
-namespace MBINCompiler.Models.Structs
+﻿namespace MBINCompiler.Models.Structs
 {
     public class TkModelRendererCameraData : NMSTemplate // 0x40 bytes
     {

--- a/MBINCompiler/Models/Structs/TkModelRendererData.cs
+++ b/MBINCompiler/Models/Structs/TkModelRendererData.cs
@@ -1,6 +1,4 @@
-﻿using System.Collections.Generic;
-
-namespace MBINCompiler.Models.Structs
+﻿namespace MBINCompiler.Models.Structs
 {
     public class TkModelRendererData : NMSTemplate // 0x70 bytes
     {

--- a/MBINCompiler/Models/Structs/TkModelResource.cs
+++ b/MBINCompiler/Models/Structs/TkModelResource.cs
@@ -4,7 +4,7 @@ namespace MBINCompiler.Models.Structs
 {
     public class TkModelResource : NMSTemplate
     {
-        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 0x80)]
+        [NMS(Size = 0x80)]
         public string Filename;
         [NMSAttribute(Ignore = true)]
         public int EmptyNode1;

--- a/MBINCompiler/Models/Structs/TkModelResource.cs
+++ b/MBINCompiler/Models/Structs/TkModelResource.cs
@@ -1,6 +1,4 @@
-﻿using System.Runtime.InteropServices;
-
-namespace MBINCompiler.Models.Structs
+﻿namespace MBINCompiler.Models.Structs
 {
     public class TkModelResource : NMSTemplate
     {

--- a/MBINCompiler/Models/Structs/TkModelResource.cs
+++ b/MBINCompiler/Models/Structs/TkModelResource.cs
@@ -6,7 +6,7 @@ namespace MBINCompiler.Models.Structs
     {
         [NMS(Size = 0x80)]
         public string Filename;
-        [NMSAttribute(Ignore = true)]
+        [NMS(Ignore = true)]
         public int EmptyNode1;
     }
 }

--- a/MBINCompiler/Models/Structs/TkNGuiGraphicStyle.cs
+++ b/MBINCompiler/Models/Structs/TkNGuiGraphicStyle.cs
@@ -1,6 +1,4 @@
-﻿using System.Runtime.InteropServices;
-
-namespace MBINCompiler.Models.Structs
+﻿namespace MBINCompiler.Models.Structs
 {
     public class TkNGuiGraphicStyle : NMSTemplate
     {

--- a/MBINCompiler/Models/Structs/TkNGuiGraphicStyle.cs
+++ b/MBINCompiler/Models/Structs/TkNGuiGraphicStyle.cs
@@ -23,8 +23,7 @@ namespace MBINCompiler.Models.Structs
         public Vector2f CustomMinStart;
         public Vector2f CustomMaxStart;
 
-        [MarshalAs( UnmanagedType.ByValArray, SizeConst = 0x4 )]
-        [NMSAttribute(Ignore = true)]
+        [NMS(Size = 0x4, Ignore = true)]
         public byte[] Padding;
     }
 }

--- a/MBINCompiler/Models/Structs/TkNGuiGraphicStyleData.cs
+++ b/MBINCompiler/Models/Structs/TkNGuiGraphicStyleData.cs
@@ -1,6 +1,4 @@
-﻿using System.Runtime.InteropServices;
-
-namespace MBINCompiler.Models.Structs
+﻿namespace MBINCompiler.Models.Structs
 {
     public class TkNGuiGraphicStyleData :NMSTemplate
     {

--- a/MBINCompiler/Models/Structs/TkNGuiGraphicStyleData.cs
+++ b/MBINCompiler/Models/Structs/TkNGuiGraphicStyleData.cs
@@ -30,8 +30,7 @@ namespace MBINCompiler.Models.Structs
         public float GradientStartOffset;
         public float GradientEndOffset;
 
-        [MarshalAs( UnmanagedType.ByValArray, SizeConst = 0xC )]
-        [NMSAttribute(Ignore = true)]
+        [NMS(Size = 0xC, Ignore = true)]
         public byte[] Padding1;
 
         public Colour GradientColour;

--- a/MBINCompiler/Models/Structs/TkNGuiLayoutListData.cs
+++ b/MBINCompiler/Models/Structs/TkNGuiLayoutListData.cs
@@ -1,6 +1,4 @@
-﻿using System.Runtime.InteropServices;
-
-namespace MBINCompiler.Models.Structs
+﻿namespace MBINCompiler.Models.Structs
 {
     public class TkNGuiLayoutListData : NMSTemplate
     {

--- a/MBINCompiler/Models/Structs/TkNGuiLayoutListData.cs
+++ b/MBINCompiler/Models/Structs/TkNGuiLayoutListData.cs
@@ -4,11 +4,11 @@ namespace MBINCompiler.Models.Structs
 {
     public class TkNGuiLayoutListData : NMSTemplate
     {
-        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 0x80)]
+        [NMS(Size = 0x80)]
         public string Name;
-        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 0x80)]
+        [NMS(Size = 0x80)]
         public string Filename;
-        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 0x80)]
+        [NMS(Size = 0x80)]
         public string Default;
     }
 }

--- a/MBINCompiler/Models/Structs/TkNGuiTextStyleData.cs
+++ b/MBINCompiler/Models/Structs/TkNGuiTextStyleData.cs
@@ -1,6 +1,4 @@
-﻿using System.Runtime.InteropServices;
-
-namespace MBINCompiler.Models.Structs
+﻿namespace MBINCompiler.Models.Structs
 {
     public class TkNGuiTextStyleData : NMSTemplate
     {

--- a/MBINCompiler/Models/Structs/TkNGuiTextStyleData.cs
+++ b/MBINCompiler/Models/Structs/TkNGuiTextStyleData.cs
@@ -11,15 +11,13 @@ namespace MBINCompiler.Models.Structs
         public bool IsIndented;
         public bool HasDropShadow;
 
-        [MarshalAs( UnmanagedType.ByValArray, SizeConst = 0x2 )]
-        [NMSAttribute(Ignore = true)]
+        [NMS(Size = 0x2, Ignore = true)]
         public byte[] Padding1;
 
         public float DropShadowOffset;
         public bool HasOutline;
 
-        [MarshalAs( UnmanagedType.ByValArray, SizeConst = 0x3 )]
-        [NMSAttribute(Ignore = true)]
+        [NMS(Size = 0x3, Ignore = true)]
         public byte[] Padding2;
 
         public float OutlineSize;
@@ -30,8 +28,7 @@ namespace MBINCompiler.Models.Structs
         public int FontIndex;
         public TkNGuiAlignment Align;
 
-        [MarshalAs( UnmanagedType.ByValArray, SizeConst = 0x8 )]
-        [NMSAttribute(Ignore = true)]
+        [NMS(Size = 0x8, Ignore = true)]
         public byte[] Padding3;
     }
 }

--- a/MBINCompiler/Models/Structs/TkParticleData.cs
+++ b/MBINCompiler/Models/Structs/TkParticleData.cs
@@ -1,6 +1,4 @@
-﻿using System.Runtime.InteropServices;
-
-namespace MBINCompiler.Models.Structs
+﻿namespace MBINCompiler.Models.Structs
 {
     public class TkParticleData : NMSTemplate
     {

--- a/MBINCompiler/Models/Structs/TkParticleData.cs
+++ b/MBINCompiler/Models/Structs/TkParticleData.cs
@@ -15,8 +15,7 @@ namespace MBINCompiler.Models.Structs
         public TkCurveType Curve1;
         public TkCurveType Curve2;
         public float EmitterSpreadAngle;
-        [MarshalAs(UnmanagedType.ByValArray, SizeConst = 8)]
-        [NMSAttribute(Ignore = true)]
+        [NMS(Size = 8, Ignore = true)]
         public byte[] Padding28;
 
         public Vector4f EmitterDirection;
@@ -41,8 +40,7 @@ namespace MBINCompiler.Models.Structs
         public float MaxRenderDistance;
         public float MaxSpawnDistance;
 
-        [MarshalAs(UnmanagedType.ByValArray, SizeConst = 8)]
-        [NMSAttribute(Ignore = true)]
+        [NMS(Size = 8, Ignore = true)]
         public byte[] PaddingB8;
     }
 }

--- a/MBINCompiler/Models/Structs/TkPhysicsComponentData.cs
+++ b/MBINCompiler/Models/Structs/TkPhysicsComponentData.cs
@@ -1,6 +1,4 @@
-﻿using System.Collections.Generic;
-
-namespace MBINCompiler.Models.Structs
+﻿namespace MBINCompiler.Models.Structs
 {
     public class TkPhysicsComponentData : NMSTemplate
     {

--- a/MBINCompiler/Models/Structs/TkPhysicsData.cs
+++ b/MBINCompiler/Models/Structs/TkPhysicsData.cs
@@ -1,6 +1,4 @@
-﻿using System.Collections.Generic;
-
-namespace MBINCompiler.Models.Structs
+﻿namespace MBINCompiler.Models.Structs
 {
     public class TkPhysicsData : NMSTemplate
     {

--- a/MBINCompiler/Models/Structs/TkProceduralTexture.cs
+++ b/MBINCompiler/Models/Structs/TkProceduralTexture.cs
@@ -4,7 +4,7 @@ namespace MBINCompiler.Models.Structs
 {
     public class TkProceduralTexture : NMSTemplate
     {
-        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 0x10)]
+        [NMS(Size = 0x10)]
         public string Name;
 
         public TkPaletteTexture Palette;
@@ -19,13 +19,13 @@ namespace MBINCompiler.Models.Structs
         public bool OverrideAverageColour;
         public Colour AverageColour;
 
-        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 0x80)]
+        [NMS(Size = 0x80)]
         public string Diffuse;
 
-        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 0x80)]
+        [NMS(Size = 0x80)]
         public string Normal;
 
-        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 0x80)]
+        [NMS(Size = 0x80)]
         public string Mask;
     }
 }

--- a/MBINCompiler/Models/Structs/TkProceduralTexture.cs
+++ b/MBINCompiler/Models/Structs/TkProceduralTexture.cs
@@ -1,6 +1,4 @@
-﻿using System.Runtime.InteropServices;
-
-namespace MBINCompiler.Models.Structs
+﻿namespace MBINCompiler.Models.Structs
 {
     public class TkProceduralTexture : NMSTemplate
     {

--- a/MBINCompiler/Models/Structs/TkProceduralTextureChosenOption.cs
+++ b/MBINCompiler/Models/Structs/TkProceduralTextureChosenOption.cs
@@ -4,14 +4,14 @@ namespace MBINCompiler.Models.Structs
 {
     public class TkProceduralTextureChosenOption : NMSTemplate
     {
-        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 0x10)]
+        [NMS(Size = 0x10)]
         public string Layer;
-        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 0x10)]
+        [NMS(Size = 0x10)]
         public string Group;
         public TkPaletteTexture Palette;
         public bool OverrideColour;
         public Colour Colour;
-        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 0x10)]
+        [NMS(Size = 0x10)]
         public string OptionName;
     }
 }

--- a/MBINCompiler/Models/Structs/TkProceduralTextureChosenOption.cs
+++ b/MBINCompiler/Models/Structs/TkProceduralTextureChosenOption.cs
@@ -1,6 +1,4 @@
-﻿using System.Runtime.InteropServices;
-
-namespace MBINCompiler.Models.Structs
+﻿namespace MBINCompiler.Models.Structs
 {
     public class TkProceduralTextureChosenOption : NMSTemplate
     {

--- a/MBINCompiler/Models/Structs/TkProceduralTextureLayer.cs
+++ b/MBINCompiler/Models/Structs/TkProceduralTextureLayer.cs
@@ -5,13 +5,13 @@ namespace MBINCompiler.Models.Structs
 {
     public class TkProceduralTextureLayer : NMSTemplate
     {
-        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 0x10)]
+        [NMS(Size = 0x10)]
         public string Name;
 
         public float Probability;
         public int Unknown14;
 
-        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 0x10)]
+        [NMS(Size = 0x10)]
         public string Group;
 
         public bool SelectToMatchBase;

--- a/MBINCompiler/Models/Structs/TkProceduralTextureLayer.cs
+++ b/MBINCompiler/Models/Structs/TkProceduralTextureLayer.cs
@@ -1,5 +1,4 @@
 ﻿using System.Collections.Generic;
-using System.Runtime.InteropServices;
 
 namespace MBINCompiler.Models.Structs
 {

--- a/MBINCompiler/Models/Structs/TkReferenceComponentData.cs
+++ b/MBINCompiler/Models/Structs/TkReferenceComponentData.cs
@@ -1,6 +1,4 @@
-﻿using System.Collections.Generic;
-
-namespace MBINCompiler.Models.Structs
+﻿namespace MBINCompiler.Models.Structs
 {
     public class TkReferenceComponentData : NMSTemplate
     {

--- a/MBINCompiler/Models/Structs/TkRotationComponentData.cs
+++ b/MBINCompiler/Models/Structs/TkRotationComponentData.cs
@@ -1,6 +1,4 @@
-﻿using System.Collections.Generic;
-
-namespace MBINCompiler.Models.Structs
+﻿namespace MBINCompiler.Models.Structs
 {
     public class TkRotationComponentData : NMSTemplate
     {

--- a/MBINCompiler/Models/Structs/TkSceneNodeAttributeData.cs
+++ b/MBINCompiler/Models/Structs/TkSceneNodeAttributeData.cs
@@ -4,11 +4,11 @@ namespace MBINCompiler.Models.Structs
 {
     public class TkSceneNodeAttributeData : NMSTemplate
     {
-        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 0x10)]
+        [NMS(Size = 0x10)]
         public string Name;
-        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 0x10)]
+        [NMS(Size = 0x10)]
         public string AltID;
-        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 0x100)]
+        [NMS(Size = 0x100)]
         public string Value;
     }
 }

--- a/MBINCompiler/Models/Structs/TkSceneNodeAttributeData.cs
+++ b/MBINCompiler/Models/Structs/TkSceneNodeAttributeData.cs
@@ -1,6 +1,4 @@
-﻿using System.Runtime.InteropServices;
-
-namespace MBINCompiler.Models.Structs
+﻿namespace MBINCompiler.Models.Structs
 {
     public class TkSceneNodeAttributeData : NMSTemplate
     {

--- a/MBINCompiler/Models/Structs/TkSceneNodeData.cs
+++ b/MBINCompiler/Models/Structs/TkSceneNodeData.cs
@@ -10,7 +10,7 @@ namespace MBINCompiler.Models.Structs
         [NMS(Size = 0x10)]
         public string Type;
         public TkTransformData Transform;
-        [NMSAttribute(Ignore = true)]
+        [NMS(Ignore = true)]
         public int EmptyNode1;
         public List<TkSceneNodeAttributeData> Attributes;
         public List<TkSceneNodeData> Children;

--- a/MBINCompiler/Models/Structs/TkSceneNodeData.cs
+++ b/MBINCompiler/Models/Structs/TkSceneNodeData.cs
@@ -5,9 +5,9 @@ namespace MBINCompiler.Models.Structs
 {
     public class TkSceneNodeData : NMSTemplate
     {
-        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 0x80)]
+        [NMS(Size = 0x80)]
         public string Name;
-        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 0x10)]
+        [NMS(Size = 0x10)]
         public string Type;
         public TkTransformData Transform;
         [NMSAttribute(Ignore = true)]

--- a/MBINCompiler/Models/Structs/TkSceneNodeData.cs
+++ b/MBINCompiler/Models/Structs/TkSceneNodeData.cs
@@ -1,5 +1,4 @@
-﻿using System.Runtime.InteropServices;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 
 namespace MBINCompiler.Models.Structs
 {

--- a/MBINCompiler/Models/Structs/TkSpeedLineData.cs
+++ b/MBINCompiler/Models/Structs/TkSpeedLineData.cs
@@ -4,7 +4,7 @@ namespace MBINCompiler.Models.Structs
 {
     public class TkSpeedLineData : NMSTemplate
     {
-        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 0x80)]
+        [NMS(Size = 0x80)]
         public string Material;
         public int NumberOfParticles;
         public float Radius;

--- a/MBINCompiler/Models/Structs/TkSpeedLineData.cs
+++ b/MBINCompiler/Models/Structs/TkSpeedLineData.cs
@@ -1,6 +1,4 @@
-﻿using System.Runtime.InteropServices;
-
-namespace MBINCompiler.Models.Structs
+﻿namespace MBINCompiler.Models.Structs
 {
     public class TkSpeedLineData : NMSTemplate
     {

--- a/MBINCompiler/Models/Structs/TkTextureResource.cs
+++ b/MBINCompiler/Models/Structs/TkTextureResource.cs
@@ -1,6 +1,4 @@
-﻿using System.Runtime.InteropServices;
-
-namespace MBINCompiler.Models.Structs
+﻿namespace MBINCompiler.Models.Structs
 {
     public class TkTextureResource : NMSTemplate
     {

--- a/MBINCompiler/Models/Structs/TkTextureResource.cs
+++ b/MBINCompiler/Models/Structs/TkTextureResource.cs
@@ -4,7 +4,7 @@ namespace MBINCompiler.Models.Structs
 {
     public class TkTextureResource : NMSTemplate
     {
-        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 0x80)]
+        [NMS(Size = 0x80)]
         public string Filename;
         [NMSAttribute(Ignore = true)]
         public int EmptyNode1;

--- a/MBINCompiler/Models/Structs/TkTextureResource.cs
+++ b/MBINCompiler/Models/Structs/TkTextureResource.cs
@@ -6,7 +6,7 @@ namespace MBINCompiler.Models.Structs
     {
         [NMS(Size = 0x80)]
         public string Filename;
-        [NMSAttribute(Ignore = true)]
+        [NMS(Ignore = true)]
         public int EmptyNode1;
     }
 }

--- a/MBINCompiler/Models/Structs/TkTrophyEntry.cs
+++ b/MBINCompiler/Models/Structs/TkTrophyEntry.cs
@@ -1,6 +1,4 @@
-﻿using System.Runtime.InteropServices;
-
-namespace MBINCompiler.Models.Structs
+﻿namespace MBINCompiler.Models.Structs
 {
     public class TkTrophyEntry : NMSTemplate
     {

--- a/MBINCompiler/Models/Structs/TkTrophyEntry.cs
+++ b/MBINCompiler/Models/Structs/TkTrophyEntry.cs
@@ -4,14 +4,13 @@ namespace MBINCompiler.Models.Structs
 {
     public class TkTrophyEntry : NMSTemplate
     {
-        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 0x10)]
+        [NMS(Size = 0x10)]
         public string TrophyId;
         public int Ps4Id;
-        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 0x40)]
+        [NMS(Size = 0x40)]
         public string PCId;
 
-        [MarshalAs(UnmanagedType.ByValArray, SizeConst = 4)]
-        [NMSAttribute(Ignore = true)]
+        [NMS(Size = 4, Ignore = true)]
         public byte[] Padding54;
     }
 }

--- a/MBINCompiler/Models/Structs/TkVertexElement.cs
+++ b/MBINCompiler/Models/Structs/TkVertexElement.cs
@@ -1,5 +1,3 @@
-using System.Runtime.InteropServices;
-
 namespace MBINCompiler.Models.Structs
 {
     public class TkVertexElement : NMSTemplate

--- a/MBINCompiler/Models/Structs/TkVertexElement.cs
+++ b/MBINCompiler/Models/Structs/TkVertexElement.cs
@@ -16,7 +16,7 @@ namespace MBINCompiler.Models.Structs
             return new[] { "PerVertex", "PerModel" };
         }
 
-        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 8)]
+        [NMS(Size = 8)]
         public string PlatformData;
     }
 }

--- a/MBINCompiler/Models/Structs/TkVertexLayout.cs
+++ b/MBINCompiler/Models/Structs/TkVertexLayout.cs
@@ -1,5 +1,4 @@
 using System.Collections.Generic;
-using System.Runtime.InteropServices;
 
 namespace MBINCompiler.Models.Structs
 {

--- a/MBINCompiler/Models/Structs/TkVertexLayout.cs
+++ b/MBINCompiler/Models/Structs/TkVertexLayout.cs
@@ -8,7 +8,7 @@ namespace MBINCompiler.Models.Structs
         public int ElementCount;
         public int Stride;
 
-        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 8)]
+        [NMS(Size = 8)]
         public string PlatformData;
 
         public List<TkVertexElement> VertexElements;

--- a/MBINCompiler/Models/Structs/Unfinished/GcBuildingGlobals.cs
+++ b/MBINCompiler/Models/Structs/Unfinished/GcBuildingGlobals.cs
@@ -1,10 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace MBINCompiler.Models.Structs
+﻿namespace MBINCompiler.Models.Structs
 {
     public class GcBuildingGlobals : NMSTemplate
     {

--- a/MBINCompiler/Models/Structs/Unfinished/GcSolarGenerationGlobals.cs
+++ b/MBINCompiler/Models/Structs/Unfinished/GcSolarGenerationGlobals.cs
@@ -1,10 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace MBINCompiler.Models.Structs
+﻿namespace MBINCompiler.Models.Structs
 {
     public class GcSolarGenerationGlobals : NMSTemplate
     {


### PR DESCRIPTION
This addresses the following points of #67:

* Change [MarshalAs(SizeConst)] attributes to [NMS(Size)] ones (and remove "using System.Runtime.interopServices" declarations)
* Ensure padding fields have [NMS(Ignore = true)] attributes

Also did some refactoring on `NMSAttribute`.