### PR TITLE
Add skeletons for GcGalaxyGlobals and its child templates

### DIFF
--- a/MBINCompiler/MBINCompiler.csproj
+++ b/MBINCompiler/MBINCompiler.csproj
@@ -537,6 +537,10 @@
     <Compile Include="Models\Structs\TkVoxelGeneratorSettingsElement.cs" />
     <Compile Include="Models\Structs\Unfinished\GcAudioGlobals.cs" />
     <Compile Include="Models\Structs\Unfinished\GcBuildingGlobals.cs" />
+    <Compile Include="Models\Structs\Unfinished\GcGalaxyGenerationSetupData.cs" />
+    <Compile Include="Models\Structs\Unfinished\GcGalaxyGlobals.cs" />
+    <Compile Include="Models\Structs\Unfinished\GcGalaxyMarkerSettings.cs" />
+    <Compile Include="Models\Structs\Unfinished\GcGalaxyRenderSetupData.cs" />
     <Compile Include="Models\Structs\Unfinished\GcGraphicsGlobals.cs" />
     <Compile Include="Models\Structs\Unfinished\GcPlacementGlobals.cs" />
     <Compile Include="Models\Structs\GcSimulationGlobals.cs" />

--- a/MBINCompiler/Models/Structs/Unfinished/GcGalaxyGenerationSetupData.cs
+++ b/MBINCompiler/Models/Structs/Unfinished/GcGalaxyGenerationSetupData.cs
@@ -1,0 +1,124 @@
+namespace MBINCompiler.Models.Structs
+{
+    public class GcGalaxyGenerationSetupData : NMSTemplate
+    {
+        // generated with MBINRawTemplateParser
+
+        public float Unknown0;     // offset: 0, sz: 4, origin: 1101004800, parsed: 20        // line:   *(_DWORD *)a1 = 1101004800;
+        public float Unknown4;     // offset: 4, sz: 4, origin: 1050253722, parsed: 0.3        // line:   *(_DWORD *)(a1 + 4) = 1050253722;
+        public float Unknown8;     // offset: 8, sz: 4, origin: 1063675494, parsed: 0.9        // line:   *(_DWORD *)(a1 + 8) = 1063675494;
+        public float UnknownC;     // offset: 12, sz: 4, origin: 1114636288, parsed: 60        // line:   *(_DWORD *)(a1 + 12) = 1114636288;
+        public float Unknown10;     // offset: 16, sz: 4, origin: 1124859904, parsed: 140        // line:   *(_DWORD *)(a1 + 16) = 1124859904;
+        public float Unknown14;     // offset: 20, sz: 4, origin: 1069547520, parsed: 1.5        // line:   *(_DWORD *)(a1 + 20) = 1069547520;
+
+        // missing 8 bytes at offset 20
+        // could be a subroutine, padding or something that the parser skipped
+        [NMS(Size = 0x8, Ignore = true)]
+        public byte[] Padding18;        // offset: 24, sz: 8, comment: auto padding 
+
+        public float Unknown20;     // offset: 32, sz: 4, origin: 1058642330, parsed: 0.6        // line:   *(_DWORD *)(a1 + 32) = 1058642330;
+        public float Unknown24;     // offset: 36, sz: 4, origin: 1060320051, parsed: 0.7        // line:   *(_DWORD *)(a1 + 36) = 1060320051;
+        public float Unknown28;     // offset: 40, sz: 4, origin: 1051931443, parsed: 0.35        // line:   *(_DWORD *)(a1 + 40) = 1051931443;
+
+        // missing 4 bytes at offset 40
+        // could be a subroutine, padding or something that the parser skipped
+        [NMS(Size = 0x4, Ignore = true)]
+        public byte[] Padding2C;        // offset: 44, sz: 4, comment: auto padding 
+
+        public float Unknown30;     // offset: 48, sz: 4, origin: 1067030938, parsed: 1.2        // line:   *(_DWORD *)(a1 + 48) = 1067030938;
+        public float Unknown34;     // offset: 52, sz: 4, origin: 1056964608, parsed: 0.5        // line:   *(_DWORD *)(a1 + 52) = 1056964608;
+        public float Unknown38;     // offset: 56, sz: 4, origin: 1094713344, parsed: 12        // line:   *(_DWORD *)(a1 + 56) = 1094713344;
+        public float Unknown3C;     // offset: 60, sz: 4, origin: 1056964608, parsed: 0.5        // line:   *(_DWORD *)(a1 + 60) = 1056964608;
+        public float Unknown40;     // offset: 64, sz: 4, origin: 1065185444, parsed: 0.99        // line:   *(_DWORD *)(a1 + 64) = 1065185444;
+        public float Unknown44;     // offset: 68, sz: 4, origin: 1036831949, parsed: 0.1        // line:   *(_DWORD *)(a1 + 68) = 1036831949;
+        public float Unknown48;     // offset: 72, sz: 4, origin: 1053273620, parsed: 0.39        // line:   *(_DWORD *)(a1 + 72) = 1053273620;
+        public float Unknown4C;     // offset: 76, sz: 4, origin: 1106247680, parsed: 30        // line:   *(_DWORD *)(a1 + 76) = 1106247680;
+        public float Unknown50;     // offset: 80, sz: 4, origin: 1114636288, parsed: 60        // line:   *(_DWORD *)(a1 + 80) = 1114636288;
+        public float Unknown54;     // offset: 84, sz: 4, origin: 1084227584, parsed: 5        // line:   *(_DWORD *)(a1 + 84) = 1084227584;
+        public float Unknown58;     // offset: 88, sz: 4, origin: 1118568448, parsed: 86        // line:   *(_DWORD *)(a1 + 88) = 1118568448;
+        public float Unknown5C;     // offset: 92, sz: 4, origin: 1106247680, parsed: 30        // line:   *(_DWORD *)(a1 + 92) = 1106247680;
+        public float Unknown60;     // offset: 96, sz: 4, origin: 1115815936, parsed: 65        // line:   *(_DWORD *)(a1 + 96) = 1115815936;
+        public float Unknown64;     // offset: 100, sz: 4, origin: 1056964608, parsed: 0.5        // line:   *(_DWORD *)(a1 + 100) = 1056964608;
+        public float Unknown68;     // offset: 104, sz: 4, origin: 1077936128, parsed: 3        // line:   *(_DWORD *)(a1 + 104) = 1077936128;
+        public float Unknown6C;     // offset: 108, sz: 4, origin: 1031127695, parsed: 0.06        // line:   *(_DWORD *)(a1 + 108) = 1031127695;
+        public float Unknown70;     // offset: 112, sz: 4, origin: 1067450368, parsed: 1.25        // line:   *(_DWORD *)(a1 + 112) = 1067450368;
+        public float Unknown74;     // offset: 116, sz: 4, origin: 1061997773, parsed: 0.8        // line:   *(_DWORD *)(a1 + 116) = 1061997773;
+        public float Unknown78;     // offset: 120, sz: 4, origin: 1056964608, parsed: 0.5        // line:   *(_DWORD *)(a1 + 120) = 1056964608;
+        public float Unknown7C;     // offset: 124, sz: 4, origin: 1056964608, parsed: 0.5        // line:   *(_DWORD *)(a1 + 124) = 1056964608;
+        public float Unknown80;     // offset: 128, sz: 4, origin: 1060320051, parsed: 0.7        // line:   *(_DWORD *)(a1 + 128) = 1060320051;
+
+        // missing 12 bytes at offset 128
+        // could be a subroutine, padding or something that the parser skipped
+        [NMS(Size = 0xC, Ignore = true)]
+        public byte[] Padding84;        // offset: 132, sz: 12, comment: auto padding 
+
+        public float Unknown90;     // offset: 144, sz: 4, origin: 1022739087, parsed: 0.03        // line:   *(_DWORD *)(a1 + 144) = 1022739087;
+        public float Unknown94;     // offset: 148, sz: 4, origin: 1028443341, parsed: 0.05        // line:   *(_DWORD *)(a1 + 148) = 1028443341;
+        public float Unknown98;     // offset: 152, sz: 4, origin: 1035489772, parsed: 0.09        // line:   *(_DWORD *)(a1 + 152) = 1035489772;
+        public float Unknown9C;     // offset: 156, sz: 4, origin: 1017370378, parsed: 0.02        // line:   *(_DWORD *)(a1 + 156) = 1017370378;
+        public float UnknownA0;     // offset: 160, sz: 4, origin: 1036831949, parsed: 0.1        // line:   *(_DWORD *)(a1 + 160) = 1036831949;
+        public float UnknownA4;     // offset: 164, sz: 4, origin: 0x40000000, parsed: 2        // line:   *(_DWORD *)(a1 + 164) = 0x40000000;
+        public float UnknownA8;     // offset: 168, sz: 4, origin: 1092616192, parsed: 10        // line:   *(_DWORD *)(a1 + 168) = 1092616192;
+        public float UnknownAC;     // offset: 172, sz: 4, origin: 1036831949, parsed: 0.1        // line:   *(_DWORD *)(a1 + 172) = 1036831949;
+        public float UnknownB0;     // offset: 176, sz: 4, origin: 1050253722, parsed: 0.3        // line:   *(_DWORD *)(a1 + 176) = 1050253722;
+        public float UnknownB4;     // offset: 180, sz: 4, origin: 1045220557, parsed: 0.2        // line:   *(_DWORD *)(a1 + 180) = 1045220557;
+        public float UnknownB8;     // offset: 184, sz: 4, origin: 1116471296, parsed: 70        // line:   *(_DWORD *)(a1 + 184) = 1116471296;
+        public float UnknownBC;     // offset: 188, sz: 4, origin: 1056964608, parsed: 0.5        // line:   *(_DWORD *)(a1 + 188) = 1056964608;
+        public float UnknownC0;     // offset: 192, sz: 4, origin: 1061997773, parsed: 0.8        // line:   *(_DWORD *)(a1 + 192) = 1061997773;
+        public float UnknownC4;     // offset: 196, sz: 4, origin: 1036831949, parsed: 0.1        // line:   *(_DWORD *)(a1 + 196) = 1036831949;
+        public float UnknownC8;     // offset: 200, sz: 4, origin: 1060320051, parsed: 0.7        // line:   *(_DWORD *)(a1 + 200) = 1060320051;
+        public float UnknownCC;     // offset: 204, sz: 4, origin: 1050253722, parsed: 0.3        // line:   *(_DWORD *)(a1 + 204) = 1050253722;
+        public float UnknownD0;     // offset: 208, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(a1 + 208) = 1065353216;
+
+        // missing 12 bytes at offset 208
+        // could be a subroutine, padding or something that the parser skipped
+        [NMS(Size = 0xC, Ignore = true)]
+        public byte[] PaddingD4;        // offset: 212, sz: 12, comment: auto padding 
+
+        public float UnknownE0;     // offset: 224, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(a1 + 224) = 1065353216;
+        public float UnknownD4;     // offset: 212, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(a1 + 212) = 1065353216;
+        public float UnknownD8;     // offset: 216, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(a1 + 216) = 1065353216;
+        public float UnknownDC;     // offset: 220, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(a1 + 220) = 1065353216;
+
+        // missing 4 bytes at offset 220
+        // could be a subroutine, padding or something that the parser skipped
+        [NMS(Size = 0x4, Ignore = true)]
+        public byte[] PaddingE0;        // offset: 224, sz: 4, comment: auto padding 
+
+        public float UnknownE4;     // offset: 228, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(a1 + 228) = 1065353216;
+        public float UnknownE8;     // offset: 232, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(a1 + 232) = 1065353216;
+        public float UnknownEC;     // offset: 236, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(a1 + 236) = 1065353216;
+        public float UnknownF0;     // offset: 240, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(a1 + 240) = 1065353216;
+        public float UnknownF4;     // offset: 244, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(a1 + 244) = 1065353216;
+        public float UnknownF8;     // offset: 248, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(a1 + 248) = 1065353216;
+        public float UnknownFC;     // offset: 252, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(a1 + 252) = 1065353216;
+        public float Unknown100;     // offset: 256, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(a1 + 256) = 1065353216;
+        public float Unknown104;     // offset: 260, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(a1 + 260) = 1065353216;
+        public float Unknown108;     // offset: 264, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(a1 + 264) = 1065353216;
+        public float Unknown10C;     // offset: 268, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(a1 + 268) = 1065353216;
+        public float Unknown110;     // offset: 272, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(a1 + 272) = 1065353216;
+        public float Unknown114;     // offset: 276, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(a1 + 276) = 1065353216;
+        public float Unknown118;     // offset: 280, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(a1 + 280) = 1065353216;
+        public float Unknown11C;     // offset: 284, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(a1 + 284) = 1065353216;
+        public float Unknown120;     // offset: 288, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(a1 + 288) = 1065353216;
+        public float Unknown124;     // offset: 292, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(a1 + 292) = 1065353216;
+        public float Unknown128;     // offset: 296, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(a1 + 296) = 1065353216;
+        public float Unknown12C;     // offset: 300, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(a1 + 300) = 1065353216;
+        public float Unknown130;     // offset: 304, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(a1 + 304) = 1065353216;
+        public float Unknown134;     // offset: 308, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(a1 + 308) = 1065353216;
+        public float Unknown138;     // offset: 312, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(a1 + 312) = 1065353216;
+        public float Unknown13C;     // offset: 316, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(a1 + 316) = 1065353216;
+        public float Unknown140;     // offset: 320, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(a1 + 320) = 1065353216;
+        public float Unknown144;     // offset: 324, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(a1 + 324) = 1065353216;
+        public float Unknown148;     // offset: 328, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(a1 + 328) = 1065353216;
+        public float Unknown14C;     // offset: 332, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(a1 + 332) = 1065353216;
+        public float Unknown150;     // offset: 336, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(a1 + 336) = 1065353216;
+        public float Unknown154;     // offset: 340, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(a1 + 340) = 1065353216;
+        public float Unknown158;     // offset: 344, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(a1 + 344) = 1065353216;
+        public float Unknown15C;     // offset: 348, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(a1 + 348) = 1065353216;
+        public float Unknown160;     // offset: 352, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(a1 + 352) = 1065353216;
+        public float Unknown164;     // offset: 356, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(a1 + 356) = 1065353216;
+        public float Unknown168;     // offset: 360, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(a1 + 360) = 1065353216;
+        public float Unknown16C;     // offset: 364, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(a1 + 364) = 1065353216;
+    }
+}

--- a/MBINCompiler/Models/Structs/Unfinished/GcGalaxyGlobals.cs
+++ b/MBINCompiler/Models/Structs/Unfinished/GcGalaxyGlobals.cs
@@ -1,0 +1,232 @@
+namespace MBINCompiler.Models.Structs
+{
+    public class GcGalaxyGlobals : NMSTemplate
+    {
+        // generated with MBINRawTemplateParser
+
+        public float Unknown0;     // offset: 0, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)a1 = 1065353216;
+        public float Unknown4;     // offset: 4, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(a1 + 4) = 1065353216;
+        public float Unknown8;     // offset: 8, sz: 4, origin: 1120927744, parsed: 104        // line:   *(_DWORD *)(a1 + 8) = 1120927744;
+        public float UnknownC;     // offset: 12, sz: 4, origin: 1119223808, parsed: 91        // line:   *(_DWORD *)(a1 + 12) = 1119223808;
+        public float Unknown10;     // offset: 16, sz: 4, origin: 1092616192, parsed: 10        // line:   *(_DWORD *)(a1 + 16) = 1092616192;
+        public float Unknown14;     // offset: 20, sz: 4, origin: 1101004800, parsed: 20        // line:   *(_DWORD *)(a1 + 20) = 1101004800;
+        public float Unknown18;     // offset: 24, sz: 4, origin: 1086324736, parsed: 6        // line:   *(_DWORD *)(a1 + 24) = 1086324736;
+        public float Unknown1C;     // offset: 28, sz: 4, origin: 1092616192, parsed: 10        // line:   *(_DWORD *)(a1 + 28) = 1092616192;
+        public float Unknown20;     // offset: 32, sz: 4, origin: 1096810496, parsed: 14        // line:   *(_DWORD *)(a1 + 32) = 1096810496;
+        public float Unknown24;     // offset: 36, sz: 4, origin: 1077936128, parsed: 3        // line:   *(_DWORD *)(a1 + 36) = 1077936128;
+        public float Unknown28;     // offset: 40, sz: 4, origin: 1074790400, parsed: 2.25        // line:   *(_DWORD *)(a1 + 40) = 1074790400;
+        public float Unknown2C;     // offset: 44, sz: 4, origin: 1065353216i64, parsed: 1, comment: two packed floats in a QWORD?(1)
+        public float Unknown30;     // offset: 48, sz: 4, origin: 1065353216i64, parsed: 0, comment: two packed floats in a QWORD?(2)        // line:   *(_QWORD *)(a1 + 44) = 1065353216i64;
+        public float Unknown34;     // offset: 52, sz: 4, origin: 0, parsed: 0        // line:   *(_DWORD *)(a1 + 52) = 0;
+
+        // missing 8 bytes at offset 52
+        // could be a subroutine, padding or something that the parser skipped
+        [NMS(Size = 0x8, Ignore = true)]
+        public byte[] Padding38;        // offset: 56, sz: 8, comment: auto padding 
+
+        public GcGalaxyMarkerSettings Template40;     // offset: 64, sz: 112, origin: sub_140141660(v1 + 64);, comment: call sub        // line:   sub_140141660(v1 + 64);
+        public GcGalaxyMarkerSettings TemplateB0;     // offset: 176, sz: 112, origin: sub_140141660(v2 + 176); // cGcGalaxyMarkerSettings, comment: call sub        // line:   sub_140141660(v2 + 176); // cGcGalaxyMarkerSettings
+        public GcGalaxyMarkerSettings Template12A;     // offset: 288, sz: 112, origin: sub_140141660(v3 + 288);, comment: call sub        // line:   sub_140141660(v3 + 298);
+        public GcGalaxyMarkerSettings Template190;     // offset: 400, sz: 112, origin: sub_140141660(v4 + 400);, comment: call sub        // line:   sub_140141660(v4 + 400);
+        public GcGalaxyMarkerSettings Template200;     // offset: 512, sz: 112, origin: sub_140141660(v5 + 512);, comment: call sub        // line:   sub_140141660(v5 + 512);
+        public GcGalaxyMarkerSettings Template270;     // offset: 624, sz: 112, origin: sub_140141660(v6 + 624);, comment: call sub        // line:   sub_140141660(v6 + 624);
+        public float Unknown2E0;     // offset: 736, sz: 4, origin: 1056964608, parsed: 0.5        // line:   *(_DWORD *)(v7 + 736) = 1056964608;
+        public float Unknown2E4;     // offset: 740, sz: 4, origin: 1080033280, parsed: 3.5        // line:   *(_DWORD *)(v7 + 740) = 1080033280;
+        public float Unknown2E8;     // offset: 744, sz: 4, origin: 1077936128, parsed: 3        // line:   *(_DWORD *)(v7 + 744) = 1077936128;
+        public float Unknown2EC;     // offset: 748, sz: 4, origin: 0x40000000, parsed: 2        // line:   *(_DWORD *)(v7 + 748) = 0x40000000;
+        public float Unknown2F0;     // offset: 752, sz: 4, origin: 0x40000000, parsed: 2        // line:   *(_DWORD *)(v7 + 752) = 0x40000000;
+        public float Unknown2F4;     // offset: 756, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(v7 + 756) = 1065353216;
+        public float Unknown2F8;     // offset: 760, sz: 4, origin: 1073951539i64, parsed: 2.05, comment: two packed floats in a QWORD?(1)
+        public float Unknown2FC;     // offset: 764, sz: 4, origin: 1073951539i64, parsed: 0, comment: two packed floats in a QWORD?(2)        // line:   *(_QWORD *)(v7 + 760) = 1073951539i64;
+        public float Unknown300;     // offset: 768, sz: 4, origin: 1117388800, parsed: 77        // line:   *(_DWORD *)(v7 + 768) = 1117388800;
+        public float Unknown304;     // offset: 772, sz: 4, origin: 1077936128, parsed: 3        // line:   *(_DWORD *)(v7 + 772) = 1077936128;
+        public float Unknown308;     // offset: 776, sz: 4, origin: 1109393408, parsed: 40        // line:   *(_DWORD *)(v7 + 776) = 1109393408;
+        public float Unknown30C;     // offset: 780, sz: 4, origin: 1036831949, parsed: 0.1        // line:   *(_DWORD *)(v7 + 780) = 1036831949;
+        public float Unknown310;     // offset: 784, sz: 4, origin: 1036831949, parsed: 0.1        // line:   *(_DWORD *)(v7 + 784) = 1036831949;
+        public float Unknown314;     // offset: 788, sz: 4, origin: 1135542272, parsed: 350        // line:   *(_DWORD *)(v7 + 788) = 1135542272;
+        public float Unknown318;     // offset: 792, sz: 4, origin: 1056964608, parsed: 0.5        // line:   *(_DWORD *)(v7 + 792) = 1056964608;
+        public float Unknown31C;     // offset: 796, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(v7 + 796) = 1065353216;
+        public float Unknown320;     // offset: 800, sz: 4, origin: 1077936128, parsed: 3        // line:   *(_DWORD *)(v7 + 800) = 1077936128;
+        public float Unknown324;     // offset: 804, sz: 4, origin: 1200142336, parsed: 70000        // line:   *(_DWORD *)(v7 + 804) = 1200142336;
+        public float Unknown328;     // offset: 808, sz: 4, origin: 1082130432, parsed: 4        // line:   *(_DWORD *)(v7 + 808) = 1082130432;
+        public float Unknown32C;     // offset: 812, sz: 4, origin: 1133903872, parsed: 300        // line:   *(_DWORD *)(v7 + 812) = 1133903872;
+        public float Unknown330;     // offset: 816, sz: 4, origin: 1109393408, parsed: 40        // line:   *(_DWORD *)(v7 + 816) = 1109393408;
+        public int Unknown334;     // offset: 820, sz: 4, origin: 10, parsed: 10        // line:   *(_DWORD *)(v7 + 820) = 10;
+        public float Unknown338;     // offset: 824, sz: 4, origin: 1036831949, parsed: 0.1        // line:   *(_DWORD *)(v7 + 824) = 1036831949;
+        public float Unknown33C;     // offset: 828, sz: 4, origin: 1045220557, parsed: 0.2        // line:   *(_DWORD *)(v7 + 828) = 1045220557;
+        public float Unknown340;     // offset: 832, sz: 4, origin: 1056964608, parsed: 0.5        // line:   *(_DWORD *)(v7 + 832) = 1056964608;
+        public float Unknown344;     // offset: 836, sz: 4, origin: 1056964608, parsed: 0.5        // line:   *(_DWORD *)(v7 + 836) = 1056964608;
+        public float Unknown348;     // offset: 840, sz: 4, origin: 1112014848, parsed: 50        // line:   *(_DWORD *)(v7 + 840) = 1112014848;
+        public float Unknown34C;     // offset: 844, sz: 4, origin: 1069547520, parsed: 1.5        // line:   *(_DWORD *)(v7 + 844) = 1069547520;
+        public float Unknown350;     // offset: 848, sz: 4, origin: 1075838976, parsed: 2.5        // line:   *(_DWORD *)(v7 + 848) = 1075838976;
+        public float Unknown354;     // offset: 852, sz: 4, origin: 1092616192, parsed: 10        // line:   *(_DWORD *)(v7 + 852) = 1092616192;
+        public float Unknown358;     // offset: 856, sz: 4, origin: 1050253722, parsed: 0.3        // line:   *(_DWORD *)(v7 + 856) = 1050253722;
+        public float Unknown35C;     // offset: 860, sz: 4, origin: 1051260355i64, parsed: 0.33, comment: two packed floats in a QWORD?(1)
+        public float Unknown360;     // offset: 864, sz: 4, origin: 1051260355i64, parsed: 0, comment: two packed floats in a QWORD?(2)        // line:   *(_QWORD *)(v7 + 860) = 1051260355i64;
+        public long Unknown364;     // offset: 868, sz: 8, origin: 0i64, parsed: 0. comment: either a long or two floats        // line:   *(_QWORD *)(v7 + 868) = 0i64;
+
+        // missing 4 bytes at offset 868
+        // could be a subroutine, padding or something that the parser skipped
+        [NMS(Size = 0x4, Ignore = true)]
+        public byte[] Padding36C;        // offset: 876, sz: 4, comment: auto padding 
+
+        public float Unknown370;     // offset: 880, sz: 4, origin: 1053609165, parsed: 0.4        // line:   *(_DWORD *)(v7 + 880) = 1053609165;
+        public float Unknown374;     // offset: 884, sz: 4, origin: 1050253722, parsed: 0.3        // line:   *(_DWORD *)(v7 + 884) = 1050253722;
+        public float Unknown378;     // offset: 888, sz: 4, origin: 1061997773, parsed: 0.8        // line:   *(_DWORD *)(v7 + 888) = 1061997773;
+        public float Unknown37C;     // offset: 892, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(v7 + 892) = 1065353216;
+        public float Unknown380;     // offset: 896, sz: 4, origin: 1048576000, parsed: 0.25        // line:   *(_DWORD *)(v7 + 896) = 1048576000;
+        public float Unknown384;     // offset: 900, sz: 4, origin: 1056964608, parsed: 0.5        // line:   *(_DWORD *)(v7 + 900) = 1056964608;
+        public float Unknown388;     // offset: 904, sz: 4, origin: 1063675494, parsed: 0.9        // line:   *(_DWORD *)(v7 + 904) = 1063675494;
+        public float Unknown38C;     // offset: 908, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(v7 + 908) = 1065353216;
+        public float Unknown390;     // offset: 912, sz: 4, origin: 1050253722, parsed: 0.3        // line:   *(_DWORD *)(v7 + 912) = 1050253722;
+        public float Unknown394;     // offset: 916, sz: 4, origin: 1036831949, parsed: 0.1        // line:   *(_DWORD *)(v7 + 916) = 1036831949;
+        public float Unknown398;     // offset: 920, sz: 4, origin: 1056964608, parsed: 0.5        // line:   *(_DWORD *)(v7 + 920) = 1056964608;
+
+        // missing 4 bytes at offset 920
+        // could be a subroutine, padding or something that the parser skipped
+        [NMS(Size = 0x4, Ignore = true)]
+        public byte[] Padding39C;        // offset: 924, sz: 4, comment: auto padding 
+
+        public float Unknown3A0;     // offset: 928, sz: 4, origin: 1053609165, parsed: 0.4        // line:   *(_DWORD *)(v7 + 928) = 1053609165;
+        public float Unknown3A4;     // offset: 932, sz: 4, origin: 1050253722, parsed: 0.3        // line:   *(_DWORD *)(v7 + 932) = 1050253722;
+        public float Unknown3A8;     // offset: 936, sz: 4, origin: 1061997773, parsed: 0.8        // line:   *(_DWORD *)(v7 + 936) = 1061997773;
+        public float Unknown3AC;     // offset: 940, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(v7 + 940) = 1065353216;
+        public float Unknown3B0;     // offset: 944, sz: 4, origin: 1048576000, parsed: 0.25        // line:   *(_DWORD *)(v7 + 944) = 1048576000;
+        public float Unknown3B4;     // offset: 948, sz: 4, origin: 1056964608, parsed: 0.5        // line:   *(_DWORD *)(v7 + 948) = 1056964608;
+        public float Unknown3B8;     // offset: 952, sz: 4, origin: 1063675494, parsed: 0.9        // line:   *(_DWORD *)(v7 + 952) = 1063675494;
+        public float Unknown3BC;     // offset: 956, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(v7 + 956) = 1065353216;
+        public float Unknown3C0;     // offset: 960, sz: 4, origin: 1050253722, parsed: 0.3        // line:   *(_DWORD *)(v7 + 960) = 1050253722;
+        public float Unknown3C4;     // offset: 964, sz: 4, origin: 1036831949, parsed: 0.1        // line:   *(_DWORD *)(v7 + 964) = 1036831949;
+        public float Unknown3C8;     // offset: 968, sz: 4, origin: 1056964608, parsed: 0.5        // line:   *(_DWORD *)(v7 + 968) = 1056964608;
+
+        // missing 4 bytes at offset 968
+        // could be a subroutine, padding or something that the parser skipped
+        [NMS(Size = 0x4, Ignore = true)]
+        public byte[] Padding3CC;        // offset: 972, sz: 4, comment: auto padding 
+
+        public float Unknown3D0;     // offset: 976, sz: 4, origin: 1064329806, parsed: 0.939        // line:   *(_DWORD *)(v7 + 976) = 1064329806;
+        public float Unknown3D4;     // offset: 980, sz: 4, origin: 1058625552, parsed: 0.599        // line:   *(_DWORD *)(v7 + 980) = 1058625552;
+        public float Unknown3D8;     // offset: 984, sz: 4, origin: 1030590824, parsed: 0.058        // line:   *(_DWORD *)(v7 + 984) = 1030590824;
+        public float Unknown3DC;     // offset: 988, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(v7 + 988) = 1065353216;
+        public float Unknown3E0;     // offset: 992, sz: 4, origin: 1062719193, parsed: 0.843        // line:   *(_DWORD *)(v7 + 992) = 1062719193;
+        public float Unknown3E4;     // offset: 996, sz: 4, origin: 1046764061, parsed: 0.223        // line:   *(_DWORD *)(v7 + 996) = 1046764061;
+        public float Unknown3E8;     // offset: 1000, sz: 4, origin: 1057434370, parsed: 0.528        // line:   *(_DWORD *)(v7 + 1000) = 1057434370;
+        public float Unknown3EC;     // offset: 1004, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(v7 + 1004) = 1065353216;
+        public float Unknown3F0;     // offset: 1008, sz: 4, origin: 1056964608, parsed: 0.5        // line:   *(_DWORD *)(v7 + 1008) = 1056964608;
+
+        // missing 12 bytes at offset 1008
+        // could be a subroutine, padding or something that the parser skipped
+        [NMS(Size = 0xC, Ignore = true)]
+        public byte[] Padding3F4;        // offset: 1012, sz: 12, comment: auto padding 
+
+        public float Unknown400;     // offset: 1024, sz: 4, origin: 1058541666, parsed: 0.594        // line:   *(_DWORD *)(v7 + 1024) = 1058541666;
+        public float Unknown404;     // offset: 1028, sz: 4, origin: 1060924031, parsed: 0.736        // line:   *(_DWORD *)(v7 + 1028) = 1060924031;
+        public float Unknown408;     // offset: 1032, sz: 4, origin: 1061746115, parsed: 0.785        // line:   *(_DWORD *)(v7 + 1032) = 1061746115;
+        public float Unknown40C;     // offset: 1036, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(v7 + 1036) = 1065353216;
+        public float Unknown410;     // offset: 1040, sz: 4, origin: 1133903872, parsed: 300        // line:   *(_DWORD *)(v7 + 1040) = 1133903872;
+        public float Unknown414;     // offset: 1044, sz: 4, origin: 1176256512, parsed: 10000        // line:   *(_DWORD *)(v7 + 1044) = 1176256512;
+
+        // missing 8 bytes at offset 1044
+        // could be a subroutine, padding or something that the parser skipped
+        [NMS(Size = 0x8, Ignore = true)]
+        public byte[] Padding418;        // offset: 1048, sz: 8, comment: auto padding 
+
+        public float Unknown420;     // offset: 1056, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(v7 + 1056) = 1065353216;
+
+        // missing 12 bytes at offset 1056
+        // could be a subroutine, padding or something that the parser skipped
+        [NMS(Size = 0xC, Ignore = true)]
+        public byte[] Padding424;        // offset: 1060, sz: 12, comment: auto padding 
+
+        public float Unknown430;     // offset: 1072, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(v7 + 1072) = 1065353216;
+        public float Unknown424;     // offset: 1060, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(v7 + 1060) = 1065353216;
+        public float Unknown428;     // offset: 1064, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(v7 + 1064) = 1065353216;
+        public float Unknown42C;     // offset: 1068, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(v7 + 1068) = 1065353216;
+
+        // missing 4 bytes at offset 1068
+        // could be a subroutine, padding or something that the parser skipped
+        [NMS(Size = 0x4, Ignore = true)]
+        public byte[] Padding430;        // offset: 1072, sz: 4, comment: auto padding 
+
+        public float Unknown434;     // offset: 1076, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(v7 + 1076) = 1065353216;
+        public float Unknown438;     // offset: 1080, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(v7 + 1080) = 1065353216;
+        public float Unknown43C;     // offset: 1084, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(v7 + 1084) = 1065353216;
+        public float Unknown440;     // offset: 1088, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(v7 + 1088) = 1065353216;
+        public float Unknown444;     // offset: 1092, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(v7 + 1092) = 1065353216;
+        public float Unknown448;     // offset: 1096, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(v7 + 1096) = 1065353216;
+        public float Unknown44C;     // offset: 1100, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(v7 + 1100) = 1065353216;
+        public float Unknown450;     // offset: 1104, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(v7 + 1104) = 1065353216;
+        public float Unknown454;     // offset: 1108, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(v7 + 1108) = 1065353216;
+        public float Unknown458;     // offset: 1112, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(v7 + 1112) = 1065353216;
+        public float Unknown45C;     // offset: 1116, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(v7 + 1116) = 1065353216;
+        public float Unknown460;     // offset: 1120, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(v7 + 1120) = 1065353216;
+
+        // missing 12 bytes at offset 1120
+        // could be a subroutine, padding or something that the parser skipped
+        [NMS(Size = 0xC, Ignore = true)]
+        public byte[] Padding464;        // offset: 1124, sz: 12, comment: auto padding 
+
+        public float Unknown470;     // offset: 1136, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(v7 + 1136) = 1065353216;
+        public float Unknown464;     // offset: 1124, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(v7 + 1124) = 1065353216;
+        public float Unknown468;     // offset: 1128, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(v7 + 1128) = 1065353216;
+        public float Unknown46C;     // offset: 1132, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(v7 + 1132) = 1065353216;
+
+        // missing 4 bytes at offset 1132
+        // could be a subroutine, padding or something that the parser skipped
+        [NMS(Size = 0x4, Ignore = true)]
+        public byte[] Padding470;        // offset: 1136, sz: 4, comment: auto padding 
+
+        public float Unknown474;     // offset: 1140, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(v7 + 1140) = 1065353216;
+        public float Unknown478;     // offset: 1144, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(v7 + 1144) = 1065353216;
+        public float Unknown47C;     // offset: 1148, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(v7 + 1148) = 1065353216;
+        public float Unknown480;     // offset: 1152, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(v7 + 1152) = 1065353216;
+        public float Unknown484;     // offset: 1156, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(v7 + 1156) = 1065353216;
+        public float Unknown488;     // offset: 1160, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(v7 + 1160) = 1065353216;
+        public float Unknown48C;     // offset: 1164, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(v7 + 1164) = 1065353216;
+        public float Unknown490;     // offset: 1168, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(v7 + 1168) = 1065353216;
+        public float Unknown494;     // offset: 1172, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(v7 + 1172) = 1065353216;
+        public float Unknown498;     // offset: 1176, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(v7 + 1176) = 1065353216;
+        public float Unknown49C;     // offset: 1180, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(v7 + 1180) = 1065353216;
+        public float Unknown4A0;     // offset: 1184, sz: 4, origin: 1120403456, parsed: 100        // line:   *(_DWORD *)(v7 + 1184) = 1120403456;
+        public float Unknown4A4;     // offset: 1188, sz: 4, origin: 1077936128, parsed: 3        // line:   *(_DWORD *)(v7 + 1188) = 1077936128;
+        public float Unknown4A8;     // offset: 1192, sz: 4, origin: 1084227584, parsed: 5        // line:   *(_DWORD *)(v7 + 1192) = 1084227584;
+        public float Unknown4AC;     // offset: 1196, sz: 4, origin: 1082130432, parsed: 4        // line:   *(_DWORD *)(v7 + 1196) = 1082130432;
+        public float Unknown4B0;     // offset: 1200, sz: 4, origin: 1063675494, parsed: 0.9        // line:   *(_DWORD *)(v7 + 1200) = 1063675494;
+        public float Unknown4B4;     // offset: 1204, sz: 4, origin: 1101004800, parsed: 20        // line:   *(_DWORD *)(v7 + 1204) = 1101004800;
+        public float Unknown4B8;     // offset: 1208, sz: 4, origin: 1128792064, parsed: 200        // line:   *(_DWORD *)(v7 + 1208) = 1128792064;
+        public float Unknown4BC;     // offset: 1212, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(v7 + 1212) = 1065353216;
+        public float Unknown4C0;     // offset: 1216, sz: 4, origin: 1076887552, parsed: 2.75        // line:   *(_DWORD *)(v7 + 1216) = 1076887552;
+        public float Unknown4C4;     // offset: 1220, sz: 4, origin: 1106247680, parsed: 30        // line:   *(_DWORD *)(v7 + 1220) = 1106247680;
+        public float Unknown4C8;     // offset: 1224, sz: 4, origin: 1123024896, parsed: 120        // line:   *(_DWORD *)(v7 + 1224) = 1123024896;
+        public float Unknown4CC;     // offset: 1228, sz: 4, origin: 0x40000000, parsed: 2        // line:   *(_DWORD *)(v7 + 1228) = 0x40000000;
+        public float Unknown4D0;     // offset: 1232, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(v7 + 1232) = 1065353216;
+        public float Unknown4D4;     // offset: 1236, sz: 4, origin: 1061997773, parsed: 0.8        // line:   *(_DWORD *)(v7 + 1236) = 1061997773;
+        public float Unknown4D8;     // offset: 1240, sz: 4, origin: -1085485875, parsed: -0.8        // line:   *(_DWORD *)(v7 + 1240) = -1085485875;
+        public float Unknown4DC;     // offset: 1244, sz: 4, origin: 1074580685, parsed: 2.2        // line:   *(_DWORD *)(v7 + 1244) = 1074580685;
+        public float Unknown4E0;     // offset: 1248, sz: 4, origin: 1053609165, parsed: 0.4        // line:   *(_DWORD *)(v7 + 1248) = 1053609165;
+        public float Unknown4E4;     // offset: 1252, sz: 4, origin: 1077936128, parsed: 3        // line:   *(_DWORD *)(v7 + 1252) = 1077936128;
+        public float Unknown4E8;     // offset: 1256, sz: 4, origin: 1050253722, parsed: 0.3        // line:   *(_DWORD *)(v7 + 1256) = 1050253722;
+        public float Unknown4EC;     // offset: 1260, sz: 4, origin: 1028443341, parsed: 0.05        // line:   *(_DWORD *)(v7 + 1260) = 1028443341;
+        public float Unknown4F0;     // offset: 1264, sz: 4, origin: 1082130432, parsed: 4        // line:   *(_DWORD *)(v7 + 1264) = 1082130432;
+        public float Unknown4F4;     // offset: 1268, sz: 4, origin: 1065353216i64, parsed: 1, comment: two packed floats in a QWORD?(1)
+        public float Unknown4F8;     // offset: 1272, sz: 4, origin: 1065353216i64, parsed: 0, comment: two packed floats in a QWORD?(2)        // line:   *(_QWORD *)(v7 + 1268) = 1065353216i64;
+        public long Unknown4FC;     // offset: 1276, sz: 8, origin: 0i64, parsed: 0. comment: either a long or two floats        // line:   *(_QWORD *)(v7 + 1276) = 0i64;
+        public long Unknown504;     // offset: 1284, sz: 8, origin: 0i64, parsed: 0. comment: either a long or two floats        // line:   *(_QWORD *)(v7 + 1284) = 0i64;
+        public long Unknown50C;     // offset: 1292, sz: 8, origin: 0i64, parsed: 0. comment: either a long or two floats        // line:   *(_QWORD *)(v7 + 1292) = 0i64;
+        public long Unknown514;     // offset: 1300, sz: 8, origin: 0i64, parsed: 0. comment: either a long or two floats        // line:   *(_QWORD *)(v7 + 1300) = 0i64;
+        public long Unknown51C;     // offset: 1308, sz: 8, origin: 0i64, parsed: 0. comment: either a long or two floats        // line:   *(_QWORD *)(v7 + 1308) = 0i64;
+        public long Unknown524;     // offset: 1316, sz: 8, origin: 0i64, parsed: 0. comment: either a long or two floats        // line:   *(_QWORD *)(v7 + 1316) = 0i64;
+        public long Unknown52C;     // offset: 1324, sz: 8, origin: 0i64, parsed: 0. comment: either a long or two floats        // line:   *(_QWORD *)(v7 + 1324) = 0i64;
+        public float Unknown534;     // offset: 1332, sz: 4, origin: 1036831949, parsed: 0.1        // line:   *(_DWORD *)(v7 + 1332) = 1036831949;
+        public float Unknown538;     // offset: 1336, sz: 4, origin: 1120403456, parsed: 100        // line:   *(_DWORD *)(v7 + 1336) = 1120403456;
+        public float Unknown53C;     // offset: 1340, sz: 4, origin: 1061997773, parsed: 0.8        // line:   *(_DWORD *)(v7 + 1340) = 1061997773;
+        public float Unknown540;     // offset: 1344, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(v7 + 1344) = 1065353216;
+        public float Unknown544;     // offset: 1348, sz: 4, origin: 1056964608, parsed: 0.5        // line:   *(_DWORD *)(v7 + 1348) = 1056964608;
+        public float Unknown548;     // offset: 1352, sz: 4, origin: 1056964608, parsed: 0.5        // line:   *(_DWORD *)(v7 + 1352) = 1056964608;
+        public float Unknown54C;     // offset: 1356, sz: 4, origin: 1041697341, parsed: 0.1475        // line:   *(_DWORD *)(v7 + 1356) = 1041697341;
+        public GcGalaxyRenderSetupData Template550;     // offset: 1360, sz: 496, origin: sub_1401440F0(v7 + 1360);, comment: call sub        // line:   sub_1401440F0(v7 + 1360);
+        public GcGalaxyGenerationSetupData Template740;     // offset: 1856, sz: 368, origin: sub_140146E20(v9 + 1856);, comment: call sub        // line:   sub_140146E20(v9 + 1856);
+        public GcGalaxyRenderSetupData Template8B0;     // offset: 2224, sz: 496, origin: sub_1401440F0(v10 + 2224);, comment: call sub        // line:   sub_1401440F0(v10 + 2224);
+        public GcGalaxyGenerationSetupData TemplateAA0;     // offset: 2720, sz: 368, origin: sub_140146E20(v11 + 2720);, comment: call sub        // line:   sub_140146E20(v11 + 2720);
+    }
+}

--- a/MBINCompiler/Models/Structs/Unfinished/GcGalaxyMarkerSettings.cs
+++ b/MBINCompiler/Models/Structs/Unfinished/GcGalaxyMarkerSettings.cs
@@ -1,0 +1,46 @@
+﻿namespace MBINCompiler.Models.Structs
+{
+    public class GcGalaxyMarkerSettings : NMSTemplate
+    {
+        // generated with MBINRawTemplateParser
+
+        public float Unknown0;     // offset: 0, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)a1 = 1065353216;
+
+        // missing 12 bytes at offset 0
+        // could be a subroutine, padding or something that the parser skipped
+        [NMS(Size = 0xC, Ignore = true)]
+        public byte[] Padding4;        // offset: 4, sz: 12, comment: auto padding 
+
+        public float Unknown10;     // offset: 16, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(a1 + 16) = 1065353216;
+        public float Unknown4;     // offset: 4, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(a1 + 4) = 1065353216;
+        public float Unknown8;     // offset: 8, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(a1 + 8) = 1065353216;
+        public float UnknownC;     // offset: 12, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(a1 + 12) = 1065353216;
+
+        // missing 4 bytes at offset 12
+        // could be a subroutine, padding or something that the parser skipped
+        [NMS(Size = 0x4, Ignore = true)]
+        public byte[] Padding10;        // offset: 16, sz: 4, comment: auto padding 
+
+        public float Unknown14;     // offset: 20, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(a1 + 20) = 1065353216;
+        public float Unknown18;     // offset: 24, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(a1 + 24) = 1065353216;
+        public float Unknown1C;     // offset: 28, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(a1 + 28) = 1065353216;
+        public float Unknown20;     // offset: 32, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(a1 + 32) = 1065353216;
+        public float Unknown24;     // offset: 36, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(a1 + 36) = 1065353216;
+        public float Unknown28;     // offset: 40, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(a1 + 40) = 1065353216;
+        public float Unknown2C;     // offset: 44, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(a1 + 44) = 1065353216;
+        public float Unknown30;     // offset: 48, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(a1 + 48) = 1065353216;
+        public float Unknown34;     // offset: 52, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(a1 + 52) = 1065353216;
+        public float Unknown38;     // offset: 56, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(a1 + 56) = 1065353216;
+        public float Unknown3C;     // offset: 60, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(a1 + 60) = 1065353216;
+        public float Unknown40;     // offset: 64, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(a1 + 64) = 1065353216;
+        public long Unknown44;     // offset: 68, sz: 8, origin: 4i64, parsed: 4        // line:   *(_QWORD *)(a1 + 68) = 4i64;
+        public float Unknown4C;     // offset: 76, sz: 4, origin: 1077936128, parsed: 3        // line:   *(_DWORD *)(a1 + 76) = 1077936128;
+        public float Unknown50;     // offset: 80, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(a1 + 80) = 1065353216;
+        public float Unknown54;     // offset: 84, sz: 4, origin: 1120403456, parsed: 100        // line:   *(_DWORD *)(a1 + 84) = 1120403456;
+        public float Unknown58;     // offset: 88, sz: 4, origin: 1092616192i64, parsed: 10, comment: two packed floats in a QWORD?(1)
+        public float Unknown5C;     // offset: 92, sz: 4, origin: 1092616192i64, parsed: 0, comment: two packed floats in a QWORD?(2)        // line:   *(_QWORD *)(a1 + 88) = 1092616192i64;
+        public float Unknown60;     // offset: 96, sz: 4, origin: 1092616192, parsed: 10        // line:   *(_DWORD *)(a1 + 96) = 1092616192;
+        public float Unknown64;     // offset: 100, sz: 4, origin: 1050253722, parsed: 0.3        // line:   *(_DWORD *)(a1 + 100) = 1050253722;
+        public float Unknown68;     // offset: 104, sz: 4, origin: 1058642330, parsed: 0.6        // line:   *(_DWORD *)(a1 + 104) = 1058642330;
+    }
+}

--- a/MBINCompiler/Models/Structs/Unfinished/GcGalaxyRenderSetupData.cs
+++ b/MBINCompiler/Models/Structs/Unfinished/GcGalaxyRenderSetupData.cs
@@ -1,0 +1,166 @@
+namespace MBINCompiler.Models.Structs
+{
+    public class GcGalaxyRenderSetupData : NMSTemplate
+    {
+        // generated with MBINRawTemplateParser
+
+        public float Unknown0;     // offset: 0, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)a1 = 1065353216;
+        public float Unknown4;     // offset: 4, sz: 4, origin: 1064497914, parsed: 0.94902        // line:   *(_DWORD *)(a1 + 4) = 1064497914;
+        public float Unknown8;     // offset: 8, sz: 4, origin: 1063247843, parsed: 0.87451        // line:   *(_DWORD *)(a1 + 8) = 1063247843;
+        public float UnknownC;     // offset: 12, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(a1 + 12) = 1065353216;
+        public float Unknown10;     // offset: 16, sz: 4, origin: 1119092736, parsed: 90        // line:   *(_DWORD *)(a1 + 16) = 1119092736;
+        public float Unknown14;     // offset: 20, sz: 4, origin: 1125515264, parsed: 150        // line:   *(_DWORD *)(a1 + 20) = 1125515264;
+        public float Unknown18;     // offset: 24, sz: 4, origin: 1071225242, parsed: 1.7        // line:   *(_DWORD *)(a1 + 24) = 1071225242;
+        public float Unknown1C;     // offset: 28, sz: 4, origin: 1058642330, parsed: 0.6        // line:   *(_DWORD *)(a1 + 28) = 1058642330;
+        public float Unknown20;     // offset: 32, sz: 4, origin: 1063675494, parsed: 0.9        // line:   *(_DWORD *)(a1 + 32) = 1063675494;
+        public float Unknown24;     // offset: 36, sz: 4, origin: 1109393408, parsed: 40        // line:   *(_DWORD *)(a1 + 36) = 1109393408;
+        public float Unknown28;     // offset: 40, sz: 4, origin: 1050253722, parsed: 0.3        // line:   *(_DWORD *)(a1 + 40) = 1050253722;
+        public float Unknown2C;     // offset: 44, sz: 4, origin: 1062836634, parsed: 0.85        // line:   *(_DWORD *)(a1 + 44) = 1062836634;
+        public float Unknown30;     // offset: 48, sz: 4, origin: 1060320051, parsed: 0.7        // line:   *(_DWORD *)(a1 + 48) = 1060320051;
+        public float Unknown34;     // offset: 52, sz: 4, origin: 1067030938, parsed: 1.2        // line:   *(_DWORD *)(a1 + 52) = 1067030938;
+        public float Unknown38;     // offset: 56, sz: 4, origin: 1058642330, parsed: 0.6        // line:   *(_DWORD *)(a1 + 56) = 1058642330;
+        public float Unknown3C;     // offset: 60, sz: 4, origin: 1077936124, parsed: 2.999999        // line:   *(_DWORD *)(a1 + 60) = 1077936124;
+        public float Unknown40;     // offset: 64, sz: 4, origin: 1069547520, parsed: 1.5        // line:   *(_DWORD *)(a1 + 64) = 1069547520;
+        public float Unknown44;     // offset: 68, sz: 4, origin: 1056964608, parsed: 0.5        // line:   *(_DWORD *)(a1 + 68) = 1056964608;
+        public float Unknown48;     // offset: 72, sz: 4, origin: 1053609165, parsed: 0.4        // line:   *(_DWORD *)(a1 + 72) = 1053609165;
+
+        // missing 4 bytes at offset 72
+        // could be a subroutine, padding or something that the parser skipped
+        [NMS(Size = 0x4, Ignore = true)]
+        public byte[] Padding4C;        // offset: 76, sz: 4, comment: auto padding 
+
+        public float Unknown50;     // offset: 80, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(a1 + 80) = 1065353216;
+        public float Unknown54;     // offset: 84, sz: 4, origin: 1064695281, parsed: 0.960784        // line:   *(_DWORD *)(a1 + 84) = 1064695281;
+        public float Unknown58;     // offset: 88, sz: 4, origin: 1063116259, parsed: 0.866667        // line:   *(_DWORD *)(a1 + 88) = 1063116259;
+        public float Unknown5C;     // offset: 92, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(a1 + 92) = 1065353216;
+        public float Unknown60;     // offset: 96, sz: 4, origin: 1061997773, parsed: 0.8        // line:   *(_DWORD *)(a1 + 96) = 1061997773;
+        public float Unknown64;     // offset: 100, sz: 4, origin: 1062836634, parsed: 0.85        // line:   *(_DWORD *)(a1 + 100) = 1062836634;
+        public float Unknown68;     // offset: 104, sz: 4, origin: 1063675494, parsed: 0.9        // line:   *(_DWORD *)(a1 + 104) = 1063675494;
+        public float Unknown6C;     // offset: 108, sz: 4, origin: 1069547520, parsed: 1.5        // line:   *(_DWORD *)(a1 + 108) = 1069547520;
+        public float Unknown70;     // offset: 112, sz: 4, origin: 1068708659, parsed: 1.4        // line:   *(_DWORD *)(a1 + 112) = 1068708659;
+        public float Unknown74;     // offset: 116, sz: 4, origin: 1063675494, parsed: 0.9        // line:   *(_DWORD *)(a1 + 116) = 1063675494;
+        public float Unknown78;     // offset: 120, sz: 4, origin: 1056964608, parsed: 0.5        // line:   *(_DWORD *)(a1 + 120) = 1056964608;
+        public float Unknown7C;     // offset: 124, sz: 4, origin: 1053609165, parsed: 0.4        // line:   *(_DWORD *)(a1 + 124) = 1053609165;
+        public float Unknown80;     // offset: 128, sz: 4, origin: -1113336054, parsed: -0.08        // line:   *(_DWORD *)(a1 + 128) = -1113336054;
+        public float Unknown84;     // offset: 132, sz: 4, origin: 1012557331, parsed: 0.01333        // line:   *(_DWORD *)(a1 + 132) = 1012557331;
+        public float Unknown88;     // offset: 136, sz: 4, origin: 1017370378, parsed: 0.02        // line:   *(_DWORD *)(a1 + 136) = 1017370378;
+
+        // missing 4 bytes at offset 136
+        // could be a subroutine, padding or something that the parser skipped
+        [NMS(Size = 0x4, Ignore = true)]
+        public byte[] Padding8C;        // offset: 140, sz: 4, comment: auto padding 
+
+        public float Unknown90;     // offset: 144, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(a1 + 144) = 1065353216;
+        public float Unknown94;     // offset: 148, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(a1 + 148) = 1065353216;
+        public float Unknown98;     // offset: 152, sz: 4, origin: 1065353216i64, parsed: 1, comment: two packed floats in a QWORD?(1)
+        public float Unknown9C;     // offset: 156, sz: 4, origin: 1065353216i64, parsed: 0, comment: two packed floats in a QWORD?(2)        // line:   *(_QWORD *)(a1 + 152) = 1065353216i64;
+        public float UnknownA0;     // offset: 160, sz: 4, origin: 1059481190i64, parsed: 0.65, comment: two packed floats in a QWORD?(1)
+        public float UnknownA4;     // offset: 164, sz: 4, origin: 1059481190i64, parsed: 0, comment: two packed floats in a QWORD?(2)        // line:   *(_QWORD *)(a1 + 160) = 1059481190i64;
+        public float UnknownA8;     // offset: 168, sz: 4, origin: 1075838976, parsed: 2.5        // line:   *(_DWORD *)(a1 + 168) = 1075838976;
+        public float UnknownAC;     // offset: 172, sz: 4, origin: 1061158912, parsed: 0.75        // line:   *(_DWORD *)(a1 + 172) = 1061158912;
+        public float UnknownB0;     // offset: 176, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(a1 + 176) = 1065353216;
+
+        // missing 12 bytes at offset 176
+        // could be a subroutine, padding or something that the parser skipped
+        [NMS(Size = 0xC, Ignore = true)]
+        public byte[] PaddingB4;        // offset: 180, sz: 12, comment: auto padding 
+
+        public float UnknownC0;     // offset: 192, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(a1 + 192) = 1065353216;
+        public float UnknownB4;     // offset: 180, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(a1 + 180) = 1065353216;
+        public float UnknownB8;     // offset: 184, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(a1 + 184) = 1065353216;
+        public float UnknownBC;     // offset: 188, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(a1 + 188) = 1065353216;
+
+        // missing 4 bytes at offset 188
+        // could be a subroutine, padding or something that the parser skipped
+        [NMS(Size = 0x4, Ignore = true)]
+        public byte[] PaddingC0;        // offset: 192, sz: 4, comment: auto padding 
+
+        public float UnknownC4;     // offset: 196, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(a1 + 196) = 1065353216;
+        public float UnknownC8;     // offset: 200, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(a1 + 200) = 1065353216;
+        public float UnknownCC;     // offset: 204, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(a1 + 204) = 1065353216;
+        public float UnknownD0;     // offset: 208, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(a1 + 208) = 1065353216;
+        public float UnknownD4;     // offset: 212, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(a1 + 212) = 1065353216;
+        public float UnknownD8;     // offset: 216, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(a1 + 216) = 1065353216;
+        public float UnknownDC;     // offset: 220, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(a1 + 220) = 1065353216;
+        public float UnknownE0;     // offset: 224, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(a1 + 224) = 1065353216;
+        public float UnknownE4;     // offset: 228, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(a1 + 228) = 1065353216;
+        public float UnknownE8;     // offset: 232, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(a1 + 232) = 1065353216;
+        public float UnknownEC;     // offset: 236, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(a1 + 236) = 1065353216;
+        public float UnknownF0;     // offset: 240, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(a1 + 240) = 1065353216;
+        public float UnknownF4;     // offset: 244, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(a1 + 244) = 1065353216;
+        public float UnknownF8;     // offset: 248, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(a1 + 248) = 1065353216;
+        public float UnknownFC;     // offset: 252, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(a1 + 252) = 1065353216;
+        public float Unknown100;     // offset: 256, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(a1 + 256) = 1065353216;
+        public float Unknown104;     // offset: 260, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(a1 + 260) = 1065353216;
+        public float Unknown108;     // offset: 264, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(a1 + 264) = 1065353216;
+        public float Unknown10C;     // offset: 268, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(a1 + 268) = 1065353216;
+        public float Unknown110;     // offset: 272, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(a1 + 272) = 1065353216;
+        public float Unknown114;     // offset: 276, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(a1 + 276) = 1065353216;
+        public float Unknown118;     // offset: 280, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(a1 + 280) = 1065353216;
+        public float Unknown11C;     // offset: 284, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(a1 + 284) = 1065353216;
+        public float Unknown120;     // offset: 288, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(a1 + 288) = 1065353216;
+        public float Unknown124;     // offset: 292, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(a1 + 292) = 1065353216;
+        public float Unknown128;     // offset: 296, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(a1 + 296) = 1065353216;
+        public float Unknown12C;     // offset: 300, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(a1 + 300) = 1065353216;
+        public float Unknown130;     // offset: 304, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(a1 + 304) = 1065353216;
+        public float Unknown134;     // offset: 308, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(a1 + 308) = 1065353216;
+        public float Unknown138;     // offset: 312, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(a1 + 312) = 1065353216;
+        public float Unknown13C;     // offset: 316, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(a1 + 316) = 1065353216;
+        public float Unknown140;     // offset: 320, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(a1 + 320) = 1065353216;
+        public float Unknown144;     // offset: 324, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(a1 + 324) = 1065353216;
+        public float Unknown148;     // offset: 328, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(a1 + 328) = 1065353216;
+        public float Unknown14C;     // offset: 332, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(a1 + 332) = 1065353216;
+        public float Unknown150;     // offset: 336, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(a1 + 336) = 1065353216;
+
+        // missing 12 bytes at offset 336
+        // could be a subroutine, padding or something that the parser skipped
+        [NMS(Size = 0xC, Ignore = true)]
+        public byte[] Padding154;        // offset: 340, sz: 12, comment: auto padding 
+
+        public float Unknown160;     // offset: 352, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(a1 + 352) = 1065353216;
+        public float Unknown154;     // offset: 340, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(a1 + 340) = 1065353216;
+        public float Unknown158;     // offset: 344, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(a1 + 344) = 1065353216;
+        public float Unknown15C;     // offset: 348, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(a1 + 348) = 1065353216;
+
+        // missing 4 bytes at offset 348
+        // could be a subroutine, padding or something that the parser skipped
+        [NMS(Size = 0x4, Ignore = true)]
+        public byte[] Padding160;        // offset: 352, sz: 4, comment: auto padding 
+
+        public float Unknown164;     // offset: 356, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(a1 + 356) = 1065353216;
+        public float Unknown168;     // offset: 360, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(a1 + 360) = 1065353216;
+        public float Unknown16C;     // offset: 364, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(a1 + 364) = 1065353216;
+        public float Unknown170;     // offset: 368, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(a1 + 368) = 1065353216;
+        public float Unknown174;     // offset: 372, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(a1 + 372) = 1065353216;
+        public float Unknown178;     // offset: 376, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(a1 + 376) = 1065353216;
+        public float Unknown17C;     // offset: 380, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(a1 + 380) = 1065353216;
+        public float Unknown180;     // offset: 384, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(a1 + 384) = 1065353216;
+        public float Unknown184;     // offset: 388, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(a1 + 388) = 1065353216;
+        public float Unknown188;     // offset: 392, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(a1 + 392) = 1065353216;
+        public float Unknown18C;     // offset: 396, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(a1 + 396) = 1065353216;
+        public float Unknown190;     // offset: 400, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(a1 + 400) = 1065353216;
+        public float Unknown194;     // offset: 404, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(a1 + 404) = 1065353216;
+        public float Unknown198;     // offset: 408, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(a1 + 408) = 1065353216;
+        public float Unknown19C;     // offset: 412, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(a1 + 412) = 1065353216;
+        public float Unknown1A0;     // offset: 416, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(a1 + 416) = 1065353216;
+        public float Unknown1A4;     // offset: 420, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(a1 + 420) = 1065353216;
+        public float Unknown1A8;     // offset: 424, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(a1 + 424) = 1065353216;
+        public float Unknown1AC;     // offset: 428, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(a1 + 428) = 1065353216;
+        public float Unknown1B0;     // offset: 432, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(a1 + 432) = 1065353216;
+        public float Unknown1B4;     // offset: 436, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(a1 + 436) = 1065353216;
+        public float Unknown1B8;     // offset: 440, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(a1 + 440) = 1065353216;
+        public float Unknown1BC;     // offset: 444, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(a1 + 444) = 1065353216;
+        public float Unknown1C0;     // offset: 448, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(a1 + 448) = 1065353216;
+        public float Unknown1C4;     // offset: 452, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(a1 + 452) = 1065353216;
+        public float Unknown1C8;     // offset: 456, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(a1 + 456) = 1065353216;
+        public float Unknown1CC;     // offset: 460, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(a1 + 460) = 1065353216;
+        public float Unknown1D0;     // offset: 464, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(a1 + 464) = 1065353216;
+        public float Unknown1D4;     // offset: 468, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(a1 + 468) = 1065353216;
+        public float Unknown1D8;     // offset: 472, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(a1 + 472) = 1065353216;
+        public float Unknown1DC;     // offset: 476, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(a1 + 476) = 1065353216;
+        public float Unknown1E0;     // offset: 480, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(a1 + 480) = 1065353216;
+        public float Unknown1E4;     // offset: 484, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(a1 + 484) = 1065353216;
+        public float Unknown1E8;     // offset: 488, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(a1 + 488) = 1065353216;
+        public float Unknown1EC;     // offset: 492, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(a1 + 492) = 1065353216;
+    }
+}


### PR DESCRIPTION
Generated with MBINRawTemplateParser. In practice, the tool is only
good to catch hidden padding and automate the whole process of writing
a RAW / skeleton template (a template without literals for its properties).

All offsets are untested in the actual disassembly.
Please, make sure you clean comments once a property is found / tested.