### PR TITLE
 add GcUIGlobals (+ GcModelViewCollection) and GcPlayerGlobals

### DIFF
--- a/MBINCompiler/MBINCompiler.csproj
+++ b/MBINCompiler/MBINCompiler.csproj
@@ -541,6 +541,7 @@
     <Compile Include="Models\Structs\TkVoxelGeneratorSettingsElement.cs" />
     <Compile Include="Models\Structs\Unfinished\GcAISpaceshipGlobals.cs" />
     <Compile Include="Models\Structs\Unfinished\GcCameraGlobals.cs" />
+    <Compile Include="Models\Structs\Unfinished\GcUIGlobals.cs" />
     <Compile Include="Models\Structs\Unfinished\GcCreatureGlobals.cs" />
     <Compile Include="Models\Structs\Unfinished\GcAudioGlobals.cs" />
     <Compile Include="Models\Structs\Unfinished\GcBuildingGlobals.cs" />

--- a/MBINCompiler/MBINCompiler.csproj
+++ b/MBINCompiler/MBINCompiler.csproj
@@ -51,6 +51,7 @@
     <Compile Include="Models\EXmlBase.cs" />
     <Compile Include="Models\EXmlData.cs" />
     <Compile Include="Models\EXmlProperty.cs" />
+    <Compile Include="Models\Structs\GcModelViewCollection.cs" />
     <Compile Include="Models\Structs\GcCameraShakeData.cs" />
     <Compile Include="Models\Structs\GcCameraShakeCaptureData.cs" />
     <Compile Include="Models\Structs\GcCameraShakeMechanicalData.cs" />

--- a/MBINCompiler/MBINCompiler.csproj
+++ b/MBINCompiler/MBINCompiler.csproj
@@ -541,6 +541,7 @@
     <Compile Include="Models\Structs\TkVoxelGeneratorSettingsElement.cs" />
     <Compile Include="Models\Structs\Unfinished\GcAISpaceshipGlobals.cs" />
     <Compile Include="Models\Structs\Unfinished\GcCameraGlobals.cs" />
+    <Compile Include="Models\Structs\Unfinished\GcPlayerGlobals.cs" />
     <Compile Include="Models\Structs\Unfinished\GcUIGlobals.cs" />
     <Compile Include="Models\Structs\Unfinished\GcCreatureGlobals.cs" />
     <Compile Include="Models\Structs\Unfinished\GcAudioGlobals.cs" />

--- a/MBINCompiler/Models/Structs/GcModelViewCollection.cs
+++ b/MBINCompiler/Models/Structs/GcModelViewCollection.cs
@@ -1,0 +1,8 @@
+﻿namespace MBINCompiler.Models.Structs
+{
+    public class GcModelViewCollection : NMSTemplate // 0x5B0
+    {
+        [NMS(Size = 13)] // 13 * 0x70 = 0x5B0
+        public TkModelRendererData[] ModelViews; // List or Array?
+    }
+}

--- a/MBINCompiler/Models/Structs/Unfinished/GcPlayerGlobals.cs
+++ b/MBINCompiler/Models/Structs/Unfinished/GcPlayerGlobals.cs
@@ -1,0 +1,649 @@
+﻿// generated output for subroutine:
+// char *__fastcall sub_140153C50(__int64 a1) -----> hash: 5FCBDD7
+// hash of whole input: A92EA4F
+
+namespace MBINCompiler.Models.Structs
+{
+    public class GcPlayerGlobals : NMSTemplate // 0x990
+    {
+        // generated with MBINRawTemplateParser
+
+        // line: char *__fastcall sub_140153C50(__int64 a1)
+        // line: {
+        // line:   __int64 v1; // rdi@1
+        // line:   char *result; // rax@1
+        public float Unknown0;     // offset: 0, sz: 4, origin: 1083179008, parsed: 4.5        // line:   *(_DWORD *)a1 = 1083179008;
+        public float Unknown4;     // offset: 4, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(a1 + 4) = 1065353216;
+        public float Unknown8;     // offset: 8, sz: 4, origin: 1069547520, parsed: 1.5        // line:   *(_DWORD *)(a1 + 8) = 1069547520;
+        public float UnknownC;     // offset: 12, sz: 4, origin: 1077936128, parsed: 3        // line:   *(_DWORD *)(a1 + 12) = 1077936128;
+        public bool Unknown10;     // offset: 16, sz: 1, origin: 0, parsed: 0        // line:   *(_BYTE *)(a1 + 16) = 0;
+
+        // missing 3 bytes at offset 16
+        // does 16 contain a DWORD?
+        [NMS(Size = 0x3, Ignore = true)]
+        public byte[] Padding11;        // offset: 17, sz: 3, comment: auto padding 
+
+        public float Unknown14;     // offset: 20, sz: 4, origin: 1090519040, parsed: 8        // line:   *(_DWORD *)(a1 + 20) = 1090519040;
+        public float Unknown18;     // offset: 24, sz: 4, origin: 1088421888, parsed: 7        // line:   *(_DWORD *)(a1 + 24) = 1088421888;
+        public float Unknown1C;     // offset: 28, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(a1 + 28) = 1065353216;
+        public float Unknown20;     // offset: 32, sz: 4, origin: 0x40000000, parsed: 2        // line:   *(_DWORD *)(a1 + 32) = 0x40000000;
+        public float Unknown24;     // offset: 36, sz: 4, origin: 1132068864, parsed: 250        // line:   *(_DWORD *)(a1 + 36) = 1132068864;
+        public float Unknown28;     // offset: 40, sz: 4, origin: 1133903872, parsed: 300        // line:   *(_DWORD *)(a1 + 40) = 1133903872;
+        public float Unknown2C;     // offset: 44, sz: 4, origin: 1112014848i64, parsed: 50, comment: unaligned to 8 bytes! two packed floats in a QWORD?(1)
+        public float Unknown30;     // offset: 48, sz: 4, origin: 1112014848i64, parsed: 0, comment: unaligned to 8 bytes! two packed floats in a QWORD?(2)        // line:   *(_QWORD *)(a1 + 44) = 1112014848i64;
+        public int Unknown34;     // offset: 52, sz: 4, origin: 257, parsed: 257        // line:   *(_DWORD *)(a1 + 52) = 257;
+        public bool Unknown38;     // offset: 56, sz: 1, origin: 0, parsed: 0        // line:   *(_BYTE *)(a1 + 56) = 0; // moved
+
+        // missing 3 bytes at offset 56
+        // does 56 contain a DWORD?
+        [NMS(Size = 0x3, Ignore = true)]
+        public byte[] Padding39;        // offset: 57, sz: 3, comment: auto padding 
+
+        public int Unknown3C;     // offset: 60, sz: 4, origin: 2, parsed: 2        // line:   *(_DWORD *)(a1 + 60) = 2;
+        public int Unknown40;     // offset: 64, sz: 4, origin: 2, parsed: 2        // line:   *(_DWORD *)(a1 + 64) = 2;
+        public float Unknown44;     // offset: 68, sz: 4, origin: 1120403456, parsed: 100        // line:   *(_DWORD *)(a1 + 68) = 1120403456;
+        public float Unknown48;     // offset: 72, sz: 4, origin: 1075838976, parsed: 2.5        // line:   *(_DWORD *)(a1 + 72) = 1075838976;
+        public float Unknown4C;     // offset: 76, sz: 4, origin: 1117126656, parsed: 75        // line:   *(_DWORD *)(a1 + 76) = 1117126656;
+        public float Unknown50;     // offset: 80, sz: 4, origin: 1120403456, parsed: 100        // line:   *(_DWORD *)(a1 + 80) = 1120403456;
+        public float Unknown54;     // offset: 84, sz: 4, origin: 1101004800, parsed: 20        // line:   *(_DWORD *)(a1 + 84) = 1101004800;
+        public float Unknown58;     // offset: 88, sz: 4, origin: 1061997773, parsed: 0.8        // line:   *(_DWORD *)(a1 + 88) = 1061997773;
+        public float Unknown5C;     // offset: 92, sz: 4, origin: 1114636288, parsed: 60        // line:   *(_DWORD *)(a1 + 92) = 1114636288;
+        public float Unknown60;     // offset: 96, sz: 4, origin: 0x40000000, parsed: 2        // line:   *(_DWORD *)(a1 + 96) = 0x40000000;
+        public float Unknown64;     // offset: 100, sz: 4, origin: 1120403456, parsed: 100        // line:   *(_DWORD *)(a1 + 100) = 1120403456;
+        public float Unknown68;     // offset: 104, sz: 4, origin: 1133903872, parsed: 300        // line:   *(_DWORD *)(a1 + 104) = 1133903872;
+        public float Unknown6C;     // offset: 108, sz: 4, origin: 1123024896, parsed: 120        // line:   *(_DWORD *)(a1 + 108) = 1123024896;
+        public float Unknown70;     // offset: 112, sz: 4, origin: 1084227584, parsed: 5        // line:   *(_DWORD *)(a1 + 112) = 1084227584;
+        public float Unknown74;     // offset: 116, sz: 4, origin: 1120403456, parsed: 100        // line:   *(_DWORD *)(a1 + 116) = 1120403456;
+        public float Unknown78;     // offset: 120, sz: 4, origin: 1077936128, parsed: 3        // line:   *(_DWORD *)(a1 + 120) = 1077936128;
+        public int Unknown7C;     // offset: 124, sz: 4, origin: 2, parsed: 2        // line:   *(_DWORD *)(a1 + 124) = 2;
+        public int Unknown80;     // offset: 128, sz: 4, origin: 2, parsed: 2        // line:   *(_DWORD *)(a1 + 128) = 2;
+        public float Unknown84;     // offset: 132, sz: 4, origin: 1077936128, parsed: 3        // line:   *(_DWORD *)(a1 + 132) = 1077936128;
+        public float Unknown88;     // offset: 136, sz: 4, origin: 1069547520, parsed: 1.5        // line:   *(_DWORD *)(a1 + 136) = 1069547520;
+        public float Unknown8C;     // offset: 140, sz: 4, origin: 0x40000000, parsed: 2        // line:   *(_DWORD *)(a1 + 140) = 0x40000000;
+        public float Unknown90;     // offset: 144, sz: 4, origin: 0x40000000, parsed: 2        // line:   *(_DWORD *)(a1 + 144) = 0x40000000;
+        public float Unknown94;     // offset: 148, sz: 4, origin: 1082130432, parsed: 4        // line:   *(_DWORD *)(a1 + 148) = 1082130432;
+        public float Unknown98;     // offset: 152, sz: 4, origin: 1077936128, parsed: 3        // line:   *(_DWORD *)(a1 + 152) = 1077936128;
+        public float Unknown9C;     // offset: 156, sz: 4, origin: 1084227584, parsed: 5        // line:   *(_DWORD *)(a1 + 156) = 1084227584;
+        public float UnknownA0;     // offset: 160, sz: 4, origin: 1085276160, parsed: 5.5        // line:   *(_DWORD *)(a1 + 160) = 1085276160;
+        public float UnknownA4;     // offset: 164, sz: 4, origin: 1167867904, parsed: 5000        // line:   *(_DWORD *)(a1 + 164) = 1167867904;
+        public float UnknownA8;     // offset: 168, sz: 4, origin: 1077936128, parsed: 3        // line:   *(_DWORD *)(a1 + 168) = 1077936128;
+        public float UnknownAC;     // offset: 172, sz: 4, origin: 1082130432, parsed: 4        // line:   *(_DWORD *)(a1 + 172) = 1082130432;
+        public float UnknownB0;     // offset: 176, sz: 4, origin: 1133903872, parsed: 300        // line:   *(_DWORD *)(a1 + 176) = 1133903872;
+        public float UnknownB4;     // offset: 180, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(a1 + 180) = 1065353216;
+        public float UnknownB8;     // offset: 184, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(a1 + 184) = 1065353216;
+        public float UnknownBC;     // offset: 188, sz: 4, origin: 1092616192, parsed: 10        // line:   *(_DWORD *)(a1 + 188) = 1092616192;
+        public float UnknownC0;     // offset: 192, sz: 4, origin: 1053609165, parsed: 0.4        // line:   *(_DWORD *)(a1 + 192) = 1053609165;
+        public float UnknownC4;     // offset: 196, sz: 4, origin: 1061158912, parsed: 0.75        // line:   *(_DWORD *)(a1 + 196) = 1061158912;
+        public float UnknownC8;     // offset: 200, sz: 4, origin: 1045220557, parsed: 0.2        // line:   *(_DWORD *)(a1 + 200) = 1045220557;
+        public float UnknownCC;     // offset: 204, sz: 4, origin: 1028443341, parsed: 0.05        // line:   *(_DWORD *)(a1 + 204) = 1028443341;
+        public float UnknownD0;     // offset: 208, sz: 4, origin: 1053609165, parsed: 0.4        // line:   *(_DWORD *)(a1 + 208) = 1053609165;
+        public float UnknownD4;     // offset: 212, sz: 4, origin: 1045220557, parsed: 0.2        // line:   *(_DWORD *)(a1 + 212) = 1045220557;
+        public float UnknownD8;     // offset: 216, sz: 4, origin: 1101004800, parsed: 20        // line:   *(_DWORD *)(a1 + 216) = 1101004800;
+        public float UnknownDC;     // offset: 220, sz: 4, origin: 1140460749, parsed: 500.1        // line:   *(_DWORD *)(a1 + 220) = 1140460749;
+        public float UnknownE0;     // offset: 224, sz: 4, origin: 1101004800, parsed: 20        // line:   *(_DWORD *)(a1 + 224) = 1101004800;
+        public float UnknownE4;     // offset: 228, sz: 4, origin: 1056964608, parsed: 0.5        // line:   *(_DWORD *)(a1 + 228) = 1056964608;
+        public float UnknownE8;     // offset: 232, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(a1 + 232) = 1065353216;
+        public int UnknownEC;     // offset: 236, sz: 4, origin: 40, parsed: 40        // line:   *(_DWORD *)(a1 + 236) = 40;
+        public float UnknownF0;     // offset: 240, sz: 4, origin: 1084227584, parsed: 5        // line:   *(_DWORD *)(a1 + 240) = 1084227584;
+        public float UnknownF4;     // offset: 244, sz: 4, origin: 1082130432, parsed: 4        // line:   *(_DWORD *)(a1 + 244) = 1082130432;
+        public int UnknownF8;     // offset: 248, sz: 4, origin: 48, parsed: 48        // line:   *(_DWORD *)(a1 + 248) = 48;
+        public int UnknownFC;     // offset: 252, sz: 4, origin: 6, parsed: 6        // line:   *(_DWORD *)(a1 + 252) = 6;
+        public float Unknown100;     // offset: 256, sz: 4, origin: 1080033280, parsed: 3.5        // line:   *(_DWORD *)(a1 + 256) = 1080033280;
+        public float Unknown104;     // offset: 260, sz: 4, origin: 1061158912, parsed: 0.75        // line:   *(_DWORD *)(a1 + 260) = 1061158912;
+        public float Unknown108;     // offset: 264, sz: 4, origin: 1045220557, parsed: 0.2        // line:   *(_DWORD *)(a1 + 264) = 1045220557;
+        public int Unknown10C;     // offset: 268, sz: 4, origin: 10, parsed: 10        // line:   *(_DWORD *)(a1 + 268) = 10;
+        public float Unknown110;     // offset: 272, sz: 4, origin: 1092616192, parsed: 10        // line:   *(_DWORD *)(a1 + 272) = 1092616192;
+        public float Unknown114;     // offset: 276, sz: 4, origin: 1067030938, parsed: 1.2        // line:   *(_DWORD *)(a1 + 276) = 1067030938;
+        public float Unknown118;     // offset: 280, sz: 4, origin: 1067030938, parsed: 1.2        // line:   *(_DWORD *)(a1 + 280) = 1067030938;
+        public float Unknown11C;     // offset: 284, sz: 4, origin: 1045220557, parsed: 0.2        // line:   *(_DWORD *)(a1 + 284) = 1045220557;
+        public float Unknown120;     // offset: 288, sz: 4, origin: 1056964608, parsed: 0.5        // line:   *(_DWORD *)(a1 + 288) = 1056964608;
+        // line: //  *(_BYTE *)(a1 + 56) = 0; // moved
+
+        // missing 12 bytes at offset 288
+        // could be padding, a undefined subroutine or a pointer accessing larger memory
+        [NMS(Size = 0xC, Ignore = true)]
+        public byte[] Padding124;        // offset: 292, sz: 12, comment: auto padding 
+
+        public float Unknown130;     // offset: 304, sz: 4, origin: 1064262697, parsed: 0.935        // line:   *(_DWORD *)(a1 + 304) = 1064262697;
+        public float Unknown134;     // offset: 308, sz: 4, origin: 1064011039, parsed: 0.92        // line:   *(_DWORD *)(a1 + 308) = 1064011039;
+        public float Unknown138;     // offset: 312, sz: 4, origin: 1063977484, parsed: 0.918        // line:   *(_DWORD *)(a1 + 312) = 1063977484;
+        public float Unknown13C;     // offset: 316, sz: 4, origin: 1055085560, parsed: 0.444        // line:   *(_DWORD *)(a1 + 316) = 1055085560;
+        // line:   v1 = a1;
+        public float Unknown140;     // offset: 320, sz: 4, origin: 1148846080, parsed: 1000        // line:   *(_DWORD *)(a1 + 320) = 1148846080;
+        public float Unknown144;     // offset: 324, sz: 4, origin: 1120403456, parsed: 100        // line:   *(_DWORD *)(a1 + 324) = 1120403456;
+        public float Unknown148;     // offset: 328, sz: 4, origin: 1050253722, parsed: 0.3        // line:   *(_DWORD *)(a1 + 328) = 1050253722;
+        public float Unknown14C;     // offset: 332, sz: 4, origin: 1045220557, parsed: 0.2        // line:   *(_DWORD *)(a1 + 332) = 1045220557;
+        public float Unknown150;     // offset: 336, sz: 4, origin: 1128792064, parsed: 200        // line:   *(_DWORD *)(a1 + 336) = 1128792064;
+        public float Unknown154;     // offset: 340, sz: 4, origin: 1090519040, parsed: 8        // line:   *(_DWORD *)(a1 + 340) = 1090519040;
+        public float Unknown158;     // offset: 344, sz: 4, origin: 1124859904, parsed: 140        // line:   *(_DWORD *)(a1 + 344) = 1124859904;
+        public float Unknown15C;     // offset: 348, sz: 4, origin: 1036831949, parsed: 0.1        // line:   *(_DWORD *)(a1 + 348) = 1036831949;
+        public float Unknown160;     // offset: 352, sz: 4, origin: 1045220557, parsed: 0.2        // line:   *(_DWORD *)(a1 + 352) = 1045220557;
+        public float Unknown164;     // offset: 356, sz: 4, origin: 1125515264, parsed: 150        // line:   *(_DWORD *)(a1 + 356) = 1125515264;
+        public float Unknown168;     // offset: 360, sz: 4, origin: 1125515264, parsed: 150        // line:   *(_DWORD *)(a1 + 360) = 1125515264;
+        public float Unknown16C;     // offset: 364, sz: 4, origin: 1082130432, parsed: 4        // line:   *(_DWORD *)(a1 + 364) = 1082130432;
+        public float Unknown170;     // offset: 368, sz: 4, origin: 1063675494, parsed: 0.9        // line:   *(_DWORD *)(a1 + 368) = 1063675494;
+        public float Unknown174;     // offset: 372, sz: 4, origin: 1058642330, parsed: 0.6        // line:   *(_DWORD *)(a1 + 372) = 1058642330;
+        public float Unknown178;     // offset: 376, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(a1 + 376) = 1065353216;
+        public float Unknown17C;     // offset: 380, sz: 4, origin: 1112014848, parsed: 50        // line:   *(_DWORD *)(a1 + 380) = 1112014848;
+        public float Unknown180;     // offset: 384, sz: 4, origin: 1080033280, parsed: 3.5        // line:   *(_DWORD *)(a1 + 384) = 1080033280;
+        public float Unknown184;     // offset: 388, sz: 4, origin: 1036831949, parsed: 0.1        // line:   *(_DWORD *)(a1 + 388) = 1036831949;
+        public float Unknown188;     // offset: 392, sz: 4, origin: 1036831949, parsed: 0.1        // line:   *(_DWORD *)(a1 + 392) = 1036831949;
+        public float Unknown18C;     // offset: 396, sz: 4, origin: 1056964608, parsed: 0.5        // line:   *(_DWORD *)(a1 + 396) = 1056964608;
+        public float Unknown190;     // offset: 400, sz: 4, origin: 1067030938, parsed: 1.2        // line:   *(_DWORD *)(a1 + 400) = 1067030938;
+        public float Unknown194;     // offset: 404, sz: 4, origin: 1017370378, parsed: 0.02        // line:   *(_DWORD *)(a1 + 404) = 1017370378;
+        public float Unknown198;     // offset: 408, sz: 4, origin: 1058642330, parsed: 0.6        // line:   *(_DWORD *)(a1 + 408) = 1058642330;
+        public float Unknown19C;     // offset: 412, sz: 4, origin: 1017370378, parsed: 0.02        // line:   *(_DWORD *)(a1 + 412) = 1017370378;
+        public float Unknown1A0;     // offset: 416, sz: 4, origin: 1067030938, parsed: 1.2        // line:   *(_DWORD *)(a1 + 416) = 1067030938;
+        public float Unknown1A4;     // offset: 420, sz: 4, origin: 1056964608, parsed: 0.5        // line:   *(_DWORD *)(a1 + 420) = 1056964608;
+        public float Unknown1A8;     // offset: 424, sz: 4, origin: 1045220557, parsed: 0.2        // line:   *(_DWORD *)(a1 + 424) = 1045220557;
+        public float Unknown1AC;     // offset: 428, sz: 4, origin: 1045220557, parsed: 0.2        // line:   *(_DWORD *)(a1 + 428) = 1045220557;
+        public float Unknown1B0;     // offset: 432, sz: 4, origin: 1056964608, parsed: 0.5        // line:   *(_DWORD *)(a1 + 432) = 1056964608;
+        public float Unknown1B4;     // offset: 436, sz: 4, origin: 1045220557, parsed: 0.2        // line:   *(_DWORD *)(a1 + 436) = 1045220557;
+        public float Unknown1B8;     // offset: 440, sz: 4, origin: 1056964608, parsed: 0.5        // line:   *(_DWORD *)(a1 + 440) = 1056964608;
+        public float Unknown1BC;     // offset: 444, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(a1 + 444) = 1065353216;
+        public float Unknown1C0;     // offset: 448, sz: 4, origin: 1077936128, parsed: 3        // line:   *(_DWORD *)(a1 + 448) = 1077936128;
+        public float Unknown1C4;     // offset: 452, sz: 4, origin: 1101004800, parsed: 20        // line:   *(_DWORD *)(a1 + 452) = 1101004800;
+        public float Unknown1C8;     // offset: 456, sz: 4, origin: 1084227584, parsed: 5        // line:   *(_DWORD *)(a1 + 456) = 1084227584;
+        public float Unknown1CC;     // offset: 460, sz: 4, origin: 1036831949, parsed: 0.1        // line:   *(_DWORD *)(a1 + 460) = 1036831949;
+        public float Unknown1D0;     // offset: 464, sz: 4, origin: 1058642330, parsed: 0.6        // line:   *(_DWORD *)(a1 + 464) = 1058642330;
+        public float Unknown1D4;     // offset: 468, sz: 4, origin: 1036831949, parsed: 0.1        // line:   *(_DWORD *)(a1 + 468) = 1036831949;
+        public float Unknown1D8;     // offset: 472, sz: 4, origin: 1101004800, parsed: 20        // line:   *(_DWORD *)(a1 + 472) = 1101004800;
+        public float Unknown1DC;     // offset: 476, sz: 4, origin: 1084227584, parsed: 5        // line:   *(_DWORD *)(a1 + 476) = 1084227584;
+        public float Unknown1E0;     // offset: 480, sz: 4, origin: 1086324736, parsed: 6        // line:   *(_DWORD *)(a1 + 480) = 1086324736;
+        public float Unknown1E4;     // offset: 484, sz: 4, origin: 1088421888, parsed: 7        // line:   *(_DWORD *)(a1 + 484) = 1088421888;
+        public float Unknown1E8;     // offset: 488, sz: 4, origin: 1092616192, parsed: 10        // line:   *(_DWORD *)(a1 + 488) = 1092616192;
+        public float Unknown1EC;     // offset: 492, sz: 4, origin: 1092616192, parsed: 10        // line:   *(_DWORD *)(a1 + 492) = 1092616192;
+        public float Unknown1F0;     // offset: 496, sz: 4, origin: -1082130432, parsed: -1        // line:   *(_DWORD *)(a1 + 496) = -1082130432;
+        public float Unknown1F4;     // offset: 500, sz: 4, origin: 1106247680, parsed: 30        // line:   *(_DWORD *)(a1 + 500) = 1106247680;
+        public float Unknown1F8;     // offset: 504, sz: 4, origin: 1114636288, parsed: 60        // line:   *(_DWORD *)(a1 + 504) = 1114636288;
+        public float Unknown1FC;     // offset: 508, sz: 4, origin: 1119092736, parsed: 90        // line:   *(_DWORD *)(a1 + 508) = 1119092736;
+        public float Unknown200;     // offset: 512, sz: 4, origin: -1082130432, parsed: -1        // line:   *(_DWORD *)(a1 + 512) = -1082130432;
+        public float Unknown204;     // offset: 516, sz: 4, origin: -1082130432, parsed: -1        // line:   *(_DWORD *)(a1 + 516) = -1082130432;
+        public float Unknown208;     // offset: 520, sz: 4, origin: 1101004800, parsed: 20        // line:   *(_DWORD *)(a1 + 520) = 1101004800;
+        public float Unknown20C;     // offset: 524, sz: 4, origin: 1109393408, parsed: 40        // line:   *(_DWORD *)(a1 + 524) = 1109393408;
+        public float Unknown210;     // offset: 528, sz: 4, origin: 1123024896, parsed: 120        // line:   *(_DWORD *)(a1 + 528) = 1123024896;
+        public float Unknown214;     // offset: 532, sz: 4, origin: -1082130432, parsed: -1        // line:   *(_DWORD *)(a1 + 532) = -1082130432;
+        public float Unknown218;     // offset: 536, sz: 4, origin: 0, parsed: 0        // line:   *(_DWORD *)(a1 + 536) = 0;
+        public float Unknown21C;     // offset: 540, sz: 4, origin: 1117782016, parsed: 80        // line:   *(_DWORD *)(a1 + 540) = 1117782016;
+        public float Unknown220;     // offset: 544, sz: 4, origin: 1092616192, parsed: 10        // line:   *(_DWORD *)(a1 + 544) = 1092616192;
+        public float Unknown224;     // offset: 548, sz: 4, origin: 1056964608, parsed: 0.5        // line:   *(_DWORD *)(a1 + 548) = 1056964608;
+        public float Unknown228;     // offset: 552, sz: 4, origin: 1109393408, parsed: 40        // line:   *(_DWORD *)(a1 + 552) = 1109393408;
+        public float Unknown22C;     // offset: 556, sz: 4, origin: 1128792064, parsed: 200        // line:   *(_DWORD *)(a1 + 556) = 1128792064;
+        public float Unknown230;     // offset: 560, sz: 4, origin: 1056964608, parsed: 0.5        // line:   *(_DWORD *)(a1 + 560) = 1056964608;
+        public float Unknown234;     // offset: 564, sz: 4, origin: 0x40000000, parsed: 2        // line:   *(_DWORD *)(a1 + 564) = 0x40000000;
+        public float Unknown238;     // offset: 568, sz: 4, origin: 1069547520, parsed: 1.5        // line:   *(_DWORD *)(a1 + 568) = 1069547520;
+        public float Unknown23C;     // offset: 572, sz: 4, origin: 0x40000000, parsed: 2        // line:   *(_DWORD *)(a1 + 572) = 0x40000000;
+        public float Unknown240;     // offset: 576, sz: 4, origin: 1086324736, parsed: 6        // line:   *(_DWORD *)(a1 + 576) = 1086324736;
+        public float Unknown244;     // offset: 580, sz: 4, origin: 1092616192, parsed: 10        // line:   *(_DWORD *)(a1 + 580) = 1092616192;
+        public float Unknown248;     // offset: 584, sz: 4, origin: 1028443341, parsed: 0.05        // line:   *(_DWORD *)(a1 + 584) = 1028443341;
+        public float Unknown24C;     // offset: 588, sz: 4, origin: 1050253722, parsed: 0.3        // line:   *(_DWORD *)(a1 + 588) = 1050253722;
+        public float Unknown250;     // offset: 592, sz: 4, origin: 1041865114, parsed: 0.15        // line:   *(_DWORD *)(a1 + 592) = 1041865114;
+        public float Unknown254;     // offset: 596, sz: 4, origin: 1058642330, parsed: 0.6        // line:   *(_DWORD *)(a1 + 596) = 1058642330;
+        public float Unknown258;     // offset: 600, sz: 4, origin: -1102263091, parsed: -0.2        // line:   *(_DWORD *)(a1 + 600) = -1102263091;
+        public float Unknown25C;     // offset: 604, sz: 4, origin: 1036831949, parsed: 0.1        // line:   *(_DWORD *)(a1 + 604) = 1036831949;
+        public float Unknown260;     // offset: 608, sz: 4, origin: 1045220557, parsed: 0.2        // line:   *(_DWORD *)(a1 + 608) = 1045220557;
+        public float Unknown264;     // offset: 612, sz: 4, origin: 1067030938, parsed: 1.2        // line:   *(_DWORD *)(a1 + 612) = 1067030938;
+        public float Unknown268;     // offset: 616, sz: 4, origin: 1075838976, parsed: 2.5        // line:   *(_DWORD *)(a1 + 616) = 1075838976;
+        public float Unknown26C;     // offset: 620, sz: 4, origin: 1056964608, parsed: 0.5        // line:   *(_DWORD *)(a1 + 620) = 1056964608;
+        public float Unknown270;     // offset: 624, sz: 4, origin: 1063675494, parsed: 0.9        // line:   *(_DWORD *)(a1 + 624) = 1063675494;
+        public float Unknown274;     // offset: 628, sz: 4, origin: 1060320051, parsed: 0.7        // line:   *(_DWORD *)(a1 + 628) = 1060320051;
+        public float Unknown278;     // offset: 632, sz: 4, origin: 1066192077, parsed: 1.1        // line:   *(_DWORD *)(a1 + 632) = 1066192077;
+        public float Unknown27C;     // offset: 636, sz: 4, origin: 1056964608, parsed: 0.5        // line:   *(_DWORD *)(a1 + 636) = 1056964608;
+        public float Unknown280;     // offset: 640, sz: 4, origin: 0x40000000, parsed: 2        // line:   *(_DWORD *)(a1 + 640) = 0x40000000;
+        public float Unknown284;     // offset: 644, sz: 4, origin: 1069547520, parsed: 1.5        // line:   *(_DWORD *)(a1 + 644) = 1069547520;
+        public float Unknown288;     // offset: 648, sz: 4, origin: 1082130432, parsed: 4        // line:   *(_DWORD *)(a1 + 648) = 1082130432;
+        public float Unknown28C;     // offset: 652, sz: 4, origin: -1102263091, parsed: -0.2        // line:   *(_DWORD *)(a1 + 652) = -1102263091;
+        public float Unknown290;     // offset: 656, sz: 4, origin: 1036831949, parsed: 0.1        // line:   *(_DWORD *)(a1 + 656) = 1036831949;
+        public float Unknown294;     // offset: 660, sz: 4, origin: 1045220557, parsed: 0.2        // line:   *(_DWORD *)(a1 + 660) = 1045220557;
+        public float Unknown298;     // offset: 664, sz: 4, origin: 1067030938, parsed: 1.2        // line:   *(_DWORD *)(a1 + 664) = 1067030938;
+        public float Unknown29C;     // offset: 668, sz: 4, origin: 1075838976, parsed: 2.5        // line:   *(_DWORD *)(a1 + 668) = 1075838976;
+        public float Unknown2A0;     // offset: 672, sz: 4, origin: 1056964608, parsed: 0.5        // line:   *(_DWORD *)(a1 + 672) = 1056964608;
+        public float Unknown2A4;     // offset: 676, sz: 4, origin: 1063675494, parsed: 0.9        // line:   *(_DWORD *)(a1 + 676) = 1063675494;
+        public float Unknown2A8;     // offset: 680, sz: 4, origin: 1060320051, parsed: 0.7        // line:   *(_DWORD *)(a1 + 680) = 1060320051;
+        public float Unknown2AC;     // offset: 684, sz: 4, origin: 1066192077, parsed: 1.1        // line:   *(_DWORD *)(a1 + 684) = 1066192077;
+        public float Unknown2B0;     // offset: 688, sz: 4, origin: 1056964608, parsed: 0.5        // line:   *(_DWORD *)(a1 + 688) = 1056964608;
+        public float Unknown2B4;     // offset: 692, sz: 4, origin: 0x40000000, parsed: 2        // line:   *(_DWORD *)(a1 + 692) = 0x40000000;
+        public float Unknown2B8;     // offset: 696, sz: 4, origin: 1069547520, parsed: 1.5        // line:   *(_DWORD *)(a1 + 696) = 1069547520;
+        public float Unknown2BC;     // offset: 700, sz: 4, origin: 1082130432, parsed: 4        // line:   *(_DWORD *)(a1 + 700) = 1082130432;
+        public float Unknown2C0;     // offset: 704, sz: 4, origin: -1102263091, parsed: -0.2        // line:   *(_DWORD *)(a1 + 704) = -1102263091;
+        public float Unknown2C4;     // offset: 708, sz: 4, origin: 1036831949, parsed: 0.1        // line:   *(_DWORD *)(a1 + 708) = 1036831949;
+        public float Unknown2C8;     // offset: 712, sz: 4, origin: 1045220557, parsed: 0.2        // line:   *(_DWORD *)(a1 + 712) = 1045220557;
+        public float Unknown2CC;     // offset: 716, sz: 4, origin: 1067030938, parsed: 1.2        // line:   *(_DWORD *)(a1 + 716) = 1067030938;
+        public float Unknown2D0;     // offset: 720, sz: 4, origin: 1075838976, parsed: 2.5        // line:   *(_DWORD *)(a1 + 720) = 1075838976;
+        public float Unknown2D4;     // offset: 724, sz: 4, origin: 1056964608, parsed: 0.5        // line:   *(_DWORD *)(a1 + 724) = 1056964608;
+        public float Unknown2D8;     // offset: 728, sz: 4, origin: 1063675494, parsed: 0.9        // line:   *(_DWORD *)(a1 + 728) = 1063675494;
+        public float Unknown2DC;     // offset: 732, sz: 4, origin: 1060320051, parsed: 0.7        // line:   *(_DWORD *)(a1 + 732) = 1060320051;
+        public float Unknown2E0;     // offset: 736, sz: 4, origin: 1066192077, parsed: 1.1        // line:   *(_DWORD *)(a1 + 736) = 1066192077;
+        public float Unknown2E4;     // offset: 740, sz: 4, origin: 1056964608, parsed: 0.5        // line:   *(_DWORD *)(a1 + 740) = 1056964608;
+        public float Unknown2E8;     // offset: 744, sz: 4, origin: 0x40000000, parsed: 2        // line:   *(_DWORD *)(a1 + 744) = 0x40000000;
+        public float Unknown2EC;     // offset: 748, sz: 4, origin: 1069547520, parsed: 1.5        // line:   *(_DWORD *)(a1 + 748) = 1069547520;
+        public float Unknown2F0;     // offset: 752, sz: 4, origin: 1082130432, parsed: 4        // line:   *(_DWORD *)(a1 + 752) = 1082130432;
+        public float Unknown2F4;     // offset: 756, sz: 4, origin: -1102263091, parsed: -0.2        // line:   *(_DWORD *)(a1 + 756) = -1102263091;
+        public float Unknown2F8;     // offset: 760, sz: 4, origin: 1036831949, parsed: 0.1        // line:   *(_DWORD *)(a1 + 760) = 1036831949;
+        public float Unknown2FC;     // offset: 764, sz: 4, origin: 1045220557, parsed: 0.2        // line:   *(_DWORD *)(a1 + 764) = 1045220557;
+        public float Unknown300;     // offset: 768, sz: 4, origin: 1067030938, parsed: 1.2        // line:   *(_DWORD *)(a1 + 768) = 1067030938;
+        public float Unknown304;     // offset: 772, sz: 4, origin: 1075838976, parsed: 2.5        // line:   *(_DWORD *)(a1 + 772) = 1075838976;
+        public float Unknown308;     // offset: 776, sz: 4, origin: 1056964608, parsed: 0.5        // line:   *(_DWORD *)(a1 + 776) = 1056964608;
+        public float Unknown30C;     // offset: 780, sz: 4, origin: 1063675494, parsed: 0.9        // line:   *(_DWORD *)(a1 + 780) = 1063675494;
+        public float Unknown310;     // offset: 784, sz: 4, origin: 1060320051, parsed: 0.7        // line:   *(_DWORD *)(a1 + 784) = 1060320051;
+        public float Unknown314;     // offset: 788, sz: 4, origin: 1066192077, parsed: 1.1        // line:   *(_DWORD *)(a1 + 788) = 1066192077;
+        public float Unknown318;     // offset: 792, sz: 4, origin: 1056964608, parsed: 0.5        // line:   *(_DWORD *)(a1 + 792) = 1056964608;
+        public float Unknown31C;     // offset: 796, sz: 4, origin: 0x40000000, parsed: 2        // line:   *(_DWORD *)(a1 + 796) = 0x40000000;
+        public float Unknown320;     // offset: 800, sz: 4, origin: 1069547520, parsed: 1.5        // line:   *(_DWORD *)(a1 + 800) = 1069547520;
+        public float Unknown324;     // offset: 804, sz: 4, origin: 1082130432, parsed: 4        // line:   *(_DWORD *)(a1 + 804) = 1082130432;
+        public float Unknown328;     // offset: 808, sz: 4, origin: 1056964608, parsed: 0.5        // line:   *(_DWORD *)(a1 + 808) = 1056964608;
+        public float Unknown32C;     // offset: 812, sz: 4, origin: 1045220557, parsed: 0.2        // line:   *(_DWORD *)(a1 + 812) = 1045220557;
+        public float Unknown330;     // offset: 816, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(a1 + 816) = 1065353216;
+        public float Unknown334;     // offset: 820, sz: 4, origin: 1092616192, parsed: 10        // line:   *(_DWORD *)(a1 + 820) = 1092616192;
+        public float Unknown338;     // offset: 824, sz: 4, origin: 1056964608, parsed: 0.5        // line:   *(_DWORD *)(a1 + 824) = 1056964608;
+        public float Unknown33C;     // offset: 828, sz: 4, origin: 0x40000000, parsed: 2        // line:   *(_DWORD *)(a1 + 828) = 0x40000000;
+        public float Unknown340;     // offset: 832, sz: 4, origin: 1133903872, parsed: 300        // line:   *(_DWORD *)(a1 + 832) = 1133903872;
+        public float Unknown344;     // offset: 836, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(a1 + 836) = 1065353216;
+        public float Unknown348;     // offset: 840, sz: 4, origin: 1036831949, parsed: 0.1        // line:   *(_DWORD *)(a1 + 840) = 1036831949;
+        public float Unknown34C;     // offset: 844, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(a1 + 844) = 1065353216;
+        public float Unknown350;     // offset: 848, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(a1 + 848) = 1065353216;
+        public float Unknown354;     // offset: 852, sz: 4, origin: 1064514355, parsed: 0.95        // line:   *(_DWORD *)(a1 + 852) = 1064514355;
+        public float Unknown358;     // offset: 856, sz: 4, origin: 1045220557, parsed: 0.2        // line:   *(_DWORD *)(a1 + 856) = 1045220557;
+        public float Unknown35C;     // offset: 860, sz: 4, origin: 1000593162, parsed: 0.005        // line:   *(_DWORD *)(a1 + 860) = 1000593162;
+        public float Unknown360;     // offset: 864, sz: 4, origin: 1097859072, parsed: 15        // line:   *(_DWORD *)(a1 + 864) = 1097859072;
+        public float Unknown364;     // offset: 868, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(a1 + 868) = 1065353216;
+        public float Unknown368;     // offset: 872, sz: 4, origin: 1084227584, parsed: 5        // line:   *(_DWORD *)(a1 + 872) = 1084227584;
+        public float Unknown36C;     // offset: 876, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(a1 + 876) = 1065353216;
+        public bool Unknown370;     // offset: 880, sz: 1, origin: 1, parsed: 1        // line:   *(_BYTE *)(a1 + 880) = 1;
+
+        // missing 3 bytes at offset 880
+        // does 880 contain a DWORD?
+        [NMS(Size = 0x3, Ignore = true)]
+        public byte[] Padding371;        // offset: 881, sz: 3, comment: auto padding 
+
+        public float Unknown374;     // offset: 884, sz: 4, origin: 1061997773, parsed: 0.8        // line:   *(_DWORD *)(a1 + 884) = 1061997773;
+        public float Unknown378;     // offset: 888, sz: 4, origin: 1128792064, parsed: 200        // line:   *(_DWORD *)(a1 + 888) = 1128792064;
+        public float Unknown37C;     // offset: 892, sz: 4, origin: 1056964608, parsed: 0.5        // line:   *(_DWORD *)(a1 + 892) = 1056964608;
+        public float Unknown380;     // offset: 896, sz: 4, origin: 1092616192, parsed: 10        // line:   *(_DWORD *)(a1 + 896) = 1092616192;
+        public float Unknown384;     // offset: 900, sz: 4, origin: 1101004800, parsed: 20        // line:   *(_DWORD *)(a1 + 900) = 1101004800;
+        public float Unknown388;     // offset: 904, sz: 4, origin: 0x40000000, parsed: 2        // line:   *(_DWORD *)(a1 + 904) = 0x40000000;
+        public float Unknown38C;     // offset: 908, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(a1 + 908) = 1065353216;
+        public float Unknown390;     // offset: 912, sz: 4, origin: 1056964608i64, parsed: 0.5, comment: unaligned to 8 bytes! two packed floats in a QWORD?(1)
+        public float Unknown394;     // offset: 916, sz: 4, origin: 1056964608i64, parsed: 0, comment: unaligned to 8 bytes! two packed floats in a QWORD?(2)        // line:   *(_QWORD *)(a1 + 912) = 1056964608i64;
+        public float Unknown398;     // offset: 920, sz: 4, origin: 0, parsed: 0        // line:   *(_DWORD *)(a1 + 920) = 0;
+        public float Unknown39C;     // offset: 924, sz: 4, origin: 1114636288, parsed: 60        // line:   *(_DWORD *)(a1 + 924) = 1114636288;
+        public float Unknown3A0;     // offset: 928, sz: 4, origin: 1161527296, parsed: 3000        // line:   *(_DWORD *)(a1 + 928) = 1161527296;
+        public float Unknown3A4;     // offset: 932, sz: 4, origin: 1128792064, parsed: 200        // line:   *(_DWORD *)(a1 + 932) = 1128792064;
+        public float Unknown3A8;     // offset: 936, sz: 4, origin: 1017370378, parsed: 0.02        // line:   *(_DWORD *)(a1 + 936) = 1017370378;
+        public float Unknown3AC;     // offset: 940, sz: 4, origin: 1008981770, parsed: 0.01        // line:   *(_DWORD *)(a1 + 940) = 1008981770;
+        public float Unknown3B0;     // offset: 944, sz: 4, origin: 1065017672, parsed: 0.98        // line:   *(_DWORD *)(a1 + 944) = 1065017672;
+        public float Unknown3B4;     // offset: 948, sz: 4, origin: 1069547520, parsed: 1.5        // line:   *(_DWORD *)(a1 + 948) = 1069547520;
+        public float Unknown3B8;     // offset: 952, sz: 4, origin: 1092616192, parsed: 10        // line:   *(_DWORD *)(a1 + 952) = 1092616192;
+        public float Unknown3BC;     // offset: 956, sz: 4, origin: 1080033280, parsed: 3.5        // line:   *(_DWORD *)(a1 + 956) = 1080033280;
+        public float Unknown3C0;     // offset: 960, sz: 4, origin: 1092616192, parsed: 10        // line:   *(_DWORD *)(a1 + 960) = 1092616192;
+        public float Unknown3C4;     // offset: 964, sz: 4, origin: 1075838976, parsed: 2.5        // line:   *(_DWORD *)(a1 + 964) = 1075838976;
+        public float Unknown3C8;     // offset: 968, sz: 4, origin: 1045220557i64, parsed: 0.2, comment: unaligned to 8 bytes! two packed floats in a QWORD?(1)
+        public float Unknown3CC;     // offset: 972, sz: 4, origin: 1045220557i64, parsed: 0, comment: unaligned to 8 bytes! two packed floats in a QWORD?(2)        // line:   *(_QWORD *)(a1 + 968) = 1045220557i64;
+        public float Unknown3D0;     // offset: 976, sz: 4, origin: 0x40000000, parsed: 2        // line:   *(_DWORD *)(a1 + 976) = 0x40000000;
+        public float Unknown3D4;     // offset: 980, sz: 4, origin: 1101004800, parsed: 20        // line:   *(_DWORD *)(a1 + 980) = 1101004800;
+        public float Unknown3D8;     // offset: 984, sz: 4, origin: 1189765120, parsed: 30000        // line:   *(_DWORD *)(a1 + 984) = 1189765120;
+        public float Unknown3DC;     // offset: 988, sz: 4, origin: 1082130432, parsed: 4        // line:   *(_DWORD *)(a1 + 988) = 1082130432;
+        public float Unknown3E0;     // offset: 992, sz: 4, origin: 1157234688, parsed: 2000        // line:   *(_DWORD *)(a1 + 992) = 1157234688;
+        public float Unknown3E4;     // offset: 996, sz: 4, origin: 1203982336, parsed: 100000        // line:   *(_DWORD *)(a1 + 996) = 1203982336;
+        public float Unknown3E8;     // offset: 1000, sz: 4, origin: 1128792064, parsed: 200        // line:   *(_DWORD *)(a1 + 1000) = 1128792064;
+        public float Unknown3EC;     // offset: 1004, sz: 4, origin: 1101004800, parsed: 20        // line:   *(_DWORD *)(a1 + 1004) = 1101004800;
+        public float Unknown3F0;     // offset: 1008, sz: 4, origin: 1109393408, parsed: 40        // line:   *(_DWORD *)(a1 + 1008) = 1109393408;
+        public int Unknown3F4;     // offset: 1012, sz: 4, origin: 10, parsed: 10        // line:   *(_DWORD *)(a1 + 1012) = 10;
+        public float Unknown3F8;     // offset: 1016, sz: 4, origin: 1117782016, parsed: 80        // line:   *(_DWORD *)(a1 + 1016) = 1117782016;
+        public float Unknown3FC;     // offset: 1020, sz: 4, origin: 1133903872, parsed: 300        // line:   *(_DWORD *)(a1 + 1020) = 1133903872;
+        public float Unknown400;     // offset: 1024, sz: 4, origin: 1100480512, parsed: 19        // line:   *(_DWORD *)(a1 + 1024) = 1100480512;
+        public float Unknown404;     // offset: 1028, sz: 4, origin: 1112014848, parsed: 50        // line:   *(_DWORD *)(a1 + 1028) = 1112014848;
+        public float Unknown408;     // offset: 1032, sz: 4, origin: 1106247680, parsed: 30        // line:   *(_DWORD *)(a1 + 1032) = 1106247680;
+        public float Unknown40C;     // offset: 1036, sz: 4, origin: 0x40000000, parsed: 2        // line:   *(_DWORD *)(a1 + 1036) = 0x40000000;
+        public float Unknown410;     // offset: 1040, sz: 4, origin: 1112014848, parsed: 50        // line:   *(_DWORD *)(a1 + 1040) = 1112014848;
+        public float Unknown414;     // offset: 1044, sz: 4, origin: 1128792064, parsed: 200        // line:   *(_DWORD *)(a1 + 1044) = 1128792064;
+        public float Unknown418;     // offset: 1048, sz: 4, origin: 1110704128, parsed: 45        // line:   *(_DWORD *)(a1 + 1048) = 1110704128;
+        public float Unknown41C;     // offset: 1052, sz: 4, origin: 1103626240, parsed: 25        // line:   *(_DWORD *)(a1 + 1052) = 1103626240;
+        public float Unknown420;     // offset: 1056, sz: 4, origin: 1123024896, parsed: 120        // line:   *(_DWORD *)(a1 + 1056) = 1123024896;
+        public float Unknown424;     // offset: 1060, sz: 4, origin: 1036831949, parsed: 0.1        // line:   *(_DWORD *)(a1 + 1060) = 1036831949;
+        [NMS(Size = 0x80)]
+        public string Unknown428;     // offset: 1064, sz: 128, origin:  "MODELS//COMMON//WEAPONS//DEFAULTGUN//DEFAULTGUN.SCENE.MBIN"        // line:   result = strncpy((char *)(a1 + 1064), "MODELS//COMMON//WEAPONS//DEFAULTGUN//DEFAULTGUN.SCENE.MBIN", 0x80ui64);
+        // line:   *(_BYTE *)(v1 + 1191) = 0;
+        public float Unknown4A8;     // offset: 1192, sz: 4, origin: 0, parsed: 0        // line:   *(_DWORD *)(v1 + 1192) = 0;
+        public float Unknown4AC;     // offset: 1196, sz: 4, origin: 1065353216i64, parsed: 1, comment: unaligned to 8 bytes! two packed floats in a QWORD?(1)
+        public float Unknown4B0;     // offset: 1200, sz: 4, origin: 1065353216i64, parsed: 0, comment: unaligned to 8 bytes! two packed floats in a QWORD?(2)        // line:   *(_QWORD *)(v1 + 1196) = 1065353216i64;
+        public float Unknown4B4;     // offset: 1204, sz: 4, origin: 1120403456, parsed: 100        // line:   *(_DWORD *)(v1 + 1204) = 1120403456;
+        public float Unknown4B8;     // offset: 1208, sz: 4, origin: 0x40000000, parsed: 2        // line:   *(_DWORD *)(v1 + 1208) = 0x40000000;
+        public float Unknown4BC;     // offset: 1212, sz: 4, origin: 1056964608, parsed: 0.5        // line:   *(_DWORD *)(v1 + 1212) = 1056964608;
+        public float Unknown4C0;     // offset: 1216, sz: 4, origin: 1098383360, parsed: 15.5        // line:   *(_DWORD *)(v1 + 1216) = 1098383360;
+        public float Unknown4C4;     // offset: 1220, sz: 4, origin: 1069547520, parsed: 1.5        // line:   *(_DWORD *)(v1 + 1220) = 1069547520;
+        public float Unknown4C8;     // offset: 1224, sz: 4, origin: 0x40000000i64, parsed: 2, comment: unaligned to 8 bytes! two packed floats in a QWORD?(1)
+        public float Unknown4CC;     // offset: 1228, sz: 4, origin: 0x40000000i64, parsed: 0, comment: unaligned to 8 bytes! two packed floats in a QWORD?(2)        // line:   *(_QWORD *)(v1 + 1224) = 0x40000000i64;
+        public float Unknown4D0;     // offset: 1232, sz: 4, origin: 0, parsed: 0        // line:   *(_DWORD *)(v1 + 1232) = 0;
+        public float Unknown4D4;     // offset: 1236, sz: 4, origin: 1120403456, parsed: 100        // line:   *(_DWORD *)(v1 + 1236) = 1120403456;
+        public float Unknown4D8;     // offset: 1240, sz: 4, origin: 1125515264, parsed: 150        // line:   *(_DWORD *)(v1 + 1240) = 1125515264;
+        public float Unknown4DC;     // offset: 1244, sz: 4, origin: 1114636288, parsed: 60        // line:   *(_DWORD *)(v1 + 1244) = 1114636288;
+        public float Unknown4E0;     // offset: 1248, sz: 4, origin: 1097859072i64, parsed: 15, comment: unaligned to 8 bytes! two packed floats in a QWORD?(1)
+        public float Unknown4E4;     // offset: 1252, sz: 4, origin: 1097859072i64, parsed: 0, comment: unaligned to 8 bytes! two packed floats in a QWORD?(2)        // line:   *(_QWORD *)(v1 + 1248) = 1097859072i64;
+        public float Unknown4E8;     // offset: 1256, sz: 4, origin: 0, parsed: 0        // line:   *(_DWORD *)(v1 + 1256) = 0;
+        public float Unknown4EC;     // offset: 1260, sz: 4, origin: 1120403456, parsed: 100        // line:   *(_DWORD *)(v1 + 1260) = 1120403456;
+        public float Unknown4F0;     // offset: 1264, sz: 4, origin: 1125515264, parsed: 150        // line:   *(_DWORD *)(v1 + 1264) = 1125515264;
+        public float Unknown4F4;     // offset: 1268, sz: 4, origin: 1114636288, parsed: 60        // line:   *(_DWORD *)(v1 + 1268) = 1114636288;
+        public float Unknown4F8;     // offset: 1272, sz: 4, origin: 1097859072i64, parsed: 15, comment: unaligned to 8 bytes! two packed floats in a QWORD?(1)
+        public float Unknown4FC;     // offset: 1276, sz: 4, origin: 1097859072i64, parsed: 0, comment: unaligned to 8 bytes! two packed floats in a QWORD?(2)        // line:   *(_QWORD *)(v1 + 1272) = 1097859072i64;
+        public float Unknown500;     // offset: 1280, sz: 4, origin: 0, parsed: 0        // line:   *(_DWORD *)(v1 + 1280) = 0;
+        public float Unknown504;     // offset: 1284, sz: 4, origin: 1120403456, parsed: 100        // line:   *(_DWORD *)(v1 + 1284) = 1120403456;
+        public float Unknown508;     // offset: 1288, sz: 4, origin: 1125515264, parsed: 150        // line:   *(_DWORD *)(v1 + 1288) = 1125515264;
+        public float Unknown50C;     // offset: 1292, sz: 4, origin: 1114636288, parsed: 60        // line:   *(_DWORD *)(v1 + 1292) = 1114636288;
+        public float Unknown510;     // offset: 1296, sz: 4, origin: 1097859072i64, parsed: 15, comment: unaligned to 8 bytes! two packed floats in a QWORD?(1)
+        public float Unknown514;     // offset: 1300, sz: 4, origin: 1097859072i64, parsed: 0, comment: unaligned to 8 bytes! two packed floats in a QWORD?(2)        // line:   *(_QWORD *)(v1 + 1296) = 1097859072i64;
+        public float Unknown518;     // offset: 1304, sz: 4, origin: 0, parsed: 0        // line:   *(_DWORD *)(v1 + 1304) = 0;
+        public float Unknown51C;     // offset: 1308, sz: 4, origin: 1120403456, parsed: 100        // line:   *(_DWORD *)(v1 + 1308) = 1120403456;
+        public float Unknown520;     // offset: 1312, sz: 4, origin: 1125515264, parsed: 150        // line:   *(_DWORD *)(v1 + 1312) = 1125515264;
+        public float Unknown524;     // offset: 1316, sz: 4, origin: 1114636288, parsed: 60        // line:   *(_DWORD *)(v1 + 1316) = 1114636288;
+        public float Unknown528;     // offset: 1320, sz: 4, origin: 1097859072i64, parsed: 15, comment: unaligned to 8 bytes! two packed floats in a QWORD?(1)
+        public float Unknown52C;     // offset: 1324, sz: 4, origin: 1097859072i64, parsed: 0, comment: unaligned to 8 bytes! two packed floats in a QWORD?(2)        // line:   *(_QWORD *)(v1 + 1320) = 1097859072i64;
+        public float Unknown530;     // offset: 1328, sz: 4, origin: 0, parsed: 0        // line:   *(_DWORD *)(v1 + 1328) = 0;
+        public float Unknown534;     // offset: 1332, sz: 4, origin: 1120403456, parsed: 100        // line:   *(_DWORD *)(v1 + 1332) = 1120403456;
+        public float Unknown538;     // offset: 1336, sz: 4, origin: 1125515264, parsed: 150        // line:   *(_DWORD *)(v1 + 1336) = 1125515264;
+        public float Unknown53C;     // offset: 1340, sz: 4, origin: 1114636288, parsed: 60        // line:   *(_DWORD *)(v1 + 1340) = 1114636288;
+        public float Unknown540;     // offset: 1344, sz: 4, origin: 1097859072i64, parsed: 15, comment: unaligned to 8 bytes! two packed floats in a QWORD?(1)
+        public float Unknown544;     // offset: 1348, sz: 4, origin: 1097859072i64, parsed: 0, comment: unaligned to 8 bytes! two packed floats in a QWORD?(2)        // line:   *(_QWORD *)(v1 + 1344) = 1097859072i64;
+        public float Unknown548;     // offset: 1352, sz: 4, origin: 0, parsed: 0        // line:   *(_DWORD *)(v1 + 1352) = 0;
+        public float Unknown54C;     // offset: 1356, sz: 4, origin: 1120403456, parsed: 100        // line:   *(_DWORD *)(v1 + 1356) = 1120403456;
+        public float Unknown550;     // offset: 1360, sz: 4, origin: 1125515264, parsed: 150        // line:   *(_DWORD *)(v1 + 1360) = 1125515264;
+        public float Unknown554;     // offset: 1364, sz: 4, origin: 1114636288, parsed: 60        // line:   *(_DWORD *)(v1 + 1364) = 1114636288;
+        public float Unknown558;     // offset: 1368, sz: 4, origin: 1097859072i64, parsed: 15, comment: unaligned to 8 bytes! two packed floats in a QWORD?(1)
+        public float Unknown55C;     // offset: 1372, sz: 4, origin: 1097859072i64, parsed: 0, comment: unaligned to 8 bytes! two packed floats in a QWORD?(2)        // line:   *(_QWORD *)(v1 + 1368) = 1097859072i64;
+        public float Unknown560;     // offset: 1376, sz: 4, origin: 0, parsed: 0        // line:   *(_DWORD *)(v1 + 1376) = 0;
+        public float Unknown564;     // offset: 1380, sz: 4, origin: 1120403456, parsed: 100        // line:   *(_DWORD *)(v1 + 1380) = 1120403456;
+        public float Unknown568;     // offset: 1384, sz: 4, origin: 1125515264, parsed: 150        // line:   *(_DWORD *)(v1 + 1384) = 1125515264;
+        public float Unknown56C;     // offset: 1388, sz: 4, origin: 1114636288, parsed: 60        // line:   *(_DWORD *)(v1 + 1388) = 1114636288;
+        public float Unknown570;     // offset: 1392, sz: 4, origin: 1097859072, parsed: 15        // line:   *(_DWORD *)(v1 + 1392) = 1097859072;
+        public float Unknown574;     // offset: 1396, sz: 4, origin: 1067869798, parsed: 1.3        // line:   *(_DWORD *)(v1 + 1396) = 1067869798;
+        public float Unknown578;     // offset: 1400, sz: 4, origin: 1025758986, parsed: 0.04        // line:   *(_DWORD *)(v1 + 1400) = 1025758986;
+        public float Unknown57C;     // offset: 1404, sz: 4, origin: 1053609165, parsed: 0.4        // line:   *(_DWORD *)(v1 + 1404) = 1053609165;
+        public float Unknown580;     // offset: 1408, sz: 4, origin: 1036831949, parsed: 0.1        // line:   *(_DWORD *)(v1 + 1408) = 1036831949;
+        public float Unknown584;     // offset: 1412, sz: 4, origin: 1041865114, parsed: 0.15        // line:   *(_DWORD *)(v1 + 1412) = 1041865114;
+        public float Unknown588;     // offset: 1416, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(v1 + 1416) = 1065353216;
+        public float Unknown58C;     // offset: 1420, sz: 4, origin: 1090519040i64, parsed: 8, comment: unaligned to 8 bytes! two packed floats in a QWORD?(1)
+        public float Unknown590;     // offset: 1424, sz: 4, origin: 1090519040i64, parsed: 0, comment: unaligned to 8 bytes! two packed floats in a QWORD?(2)        // line:   *(_QWORD *)(v1 + 1420) = 1090519040i64;
+        public float Unknown594;     // offset: 1428, sz: 4, origin: 1065353216i64, parsed: 1, comment: unaligned to 8 bytes! two packed floats in a QWORD?(1)
+        public float Unknown598;     // offset: 1432, sz: 4, origin: 1065353216i64, parsed: 0, comment: unaligned to 8 bytes! two packed floats in a QWORD?(2)        // line:   *(_QWORD *)(v1 + 1428) = 1065353216i64;
+        public float Unknown59C;     // offset: 1436, sz: 4, origin: 1145569280, parsed: 800        // line:   *(_DWORD *)(v1 + 1436) = 1145569280;
+        public float Unknown5A0;     // offset: 1440, sz: 4, origin: 1128792064, parsed: 200        // line:   *(_DWORD *)(v1 + 1440) = 1128792064;
+        public float Unknown5A4;     // offset: 1444, sz: 4, origin: 1157234688, parsed: 2000        // line:   *(_DWORD *)(v1 + 1444) = 1157234688;
+        public float Unknown5A8;     // offset: 1448, sz: 4, origin: 1036831949, parsed: 0.1        // line:   *(_DWORD *)(v1 + 1448) = 1036831949;
+        public float Unknown5AC;     // offset: 1452, sz: 4, origin: 1041865114, parsed: 0.15        // line:   *(_DWORD *)(v1 + 1452) = 1041865114;
+        public float Unknown5B0;     // offset: 1456, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(v1 + 1456) = 1065353216;
+        public float Unknown5B4;     // offset: 1460, sz: 4, origin: 1090519040i64, parsed: 8, comment: unaligned to 8 bytes! two packed floats in a QWORD?(1)
+        public float Unknown5B8;     // offset: 1464, sz: 4, origin: 1090519040i64, parsed: 0, comment: unaligned to 8 bytes! two packed floats in a QWORD?(2)        // line:   *(_QWORD *)(v1 + 1460) = 1090519040i64;
+        public float Unknown5BC;     // offset: 1468, sz: 4, origin: 1065353216i64, parsed: 1, comment: unaligned to 8 bytes! two packed floats in a QWORD?(1)
+        public float Unknown5C0;     // offset: 1472, sz: 4, origin: 1065353216i64, parsed: 0, comment: unaligned to 8 bytes! two packed floats in a QWORD?(2)        // line:   *(_QWORD *)(v1 + 1468) = 1065353216i64;
+        public float Unknown5C4;     // offset: 1476, sz: 4, origin: 1145569280, parsed: 800        // line:   *(_DWORD *)(v1 + 1476) = 1145569280;
+        public float Unknown5C8;     // offset: 1480, sz: 4, origin: 1128792064, parsed: 200        // line:   *(_DWORD *)(v1 + 1480) = 1128792064;
+        public float Unknown5CC;     // offset: 1484, sz: 4, origin: 1157234688, parsed: 2000        // line:   *(_DWORD *)(v1 + 1484) = 1157234688;
+        public float Unknown5D0;     // offset: 1488, sz: 4, origin: 1036831949, parsed: 0.1        // line:   *(_DWORD *)(v1 + 1488) = 1036831949;
+        public float Unknown5D4;     // offset: 1492, sz: 4, origin: 1041865114, parsed: 0.15        // line:   *(_DWORD *)(v1 + 1492) = 1041865114;
+        public float Unknown5D8;     // offset: 1496, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(v1 + 1496) = 1065353216;
+        public float Unknown5DC;     // offset: 1500, sz: 4, origin: 1090519040i64, parsed: 8, comment: unaligned to 8 bytes! two packed floats in a QWORD?(1)
+        public float Unknown5E0;     // offset: 1504, sz: 4, origin: 1090519040i64, parsed: 0, comment: unaligned to 8 bytes! two packed floats in a QWORD?(2)        // line:   *(_QWORD *)(v1 + 1500) = 1090519040i64;
+        public float Unknown5E4;     // offset: 1508, sz: 4, origin: 1065353216i64, parsed: 1, comment: unaligned to 8 bytes! two packed floats in a QWORD?(1)
+        public float Unknown5E8;     // offset: 1512, sz: 4, origin: 1065353216i64, parsed: 0, comment: unaligned to 8 bytes! two packed floats in a QWORD?(2)        // line:   *(_QWORD *)(v1 + 1508) = 1065353216i64;
+        public float Unknown5EC;     // offset: 1516, sz: 4, origin: 1145569280, parsed: 800        // line:   *(_DWORD *)(v1 + 1516) = 1145569280;
+        public float Unknown5F0;     // offset: 1520, sz: 4, origin: 1128792064, parsed: 200        // line:   *(_DWORD *)(v1 + 1520) = 1128792064;
+        public float Unknown5F4;     // offset: 1524, sz: 4, origin: 1157234688, parsed: 2000        // line:   *(_DWORD *)(v1 + 1524) = 1157234688;
+        public float Unknown5F8;     // offset: 1528, sz: 4, origin: 1101004800, parsed: 20        // line:   *(_DWORD *)(v1 + 1528) = 1101004800;
+        public float Unknown5FC;     // offset: 1532, sz: 4, origin: 1061997773, parsed: 0.8        // line:   *(_DWORD *)(v1 + 1532) = 1061997773;
+        public float Unknown600;     // offset: 1536, sz: 4, origin: 1058642330, parsed: 0.6        // line:   *(_DWORD *)(v1 + 1536) = 1058642330;
+        public float Unknown604;     // offset: 1540, sz: 4, origin: -1130113270, parsed: -0.02        // line:   *(_DWORD *)(v1 + 1540) = -1130113270;
+        public float Unknown608;     // offset: 1544, sz: 4, origin: 0, parsed: 0        // line:   *(_DWORD *)(v1 + 1544) = 0;
+        public float Unknown60C;     // offset: 1548, sz: 4, origin: 1036831949, parsed: 0.1        // line:   *(_DWORD *)(v1 + 1548) = 1036831949;
+        public float Unknown610;     // offset: 1552, sz: 4, origin: 1036831949, parsed: 0.1        // line:   *(_DWORD *)(v1 + 1552) = 1036831949;
+        public float Unknown614;     // offset: 1556, sz: 4, origin: 1034147594, parsed: 0.08        // line:   *(_DWORD *)(v1 + 1556) = 1034147594;
+        public float Unknown618;     // offset: 1560, sz: 4, origin: 1036831949i64, parsed: 0.1, comment: unaligned to 8 bytes! two packed floats in a QWORD?(1)
+        public float Unknown61C;     // offset: 1564, sz: 4, origin: 1036831949i64, parsed: 0, comment: unaligned to 8 bytes! two packed floats in a QWORD?(2)        // line:   *(_QWORD *)(v1 + 1560) = 1036831949i64;
+        public float Unknown620;     // offset: 1568, sz: 4, origin: -1082130432, parsed: -1        // line:   *(_DWORD *)(v1 + 1568) = -1082130432;
+        public float Unknown624;     // offset: 1572, sz: 4, origin: 1058642330, parsed: 0.6        // line:   *(_DWORD *)(v1 + 1572) = 1058642330;
+        public float Unknown628;     // offset: 1576, sz: 4, origin: 1025758986, parsed: 0.04        // line:   *(_DWORD *)(v1 + 1576) = 1025758986;
+        public float Unknown62C;     // offset: 1580, sz: 4, origin: 1056964608, parsed: 0.5        // line:   *(_DWORD *)(v1 + 1580) = 1056964608;
+        public float Unknown630;     // offset: 1584, sz: 4, origin: 1092616192, parsed: 10        // line:   *(_DWORD *)(v1 + 1584) = 1092616192;
+        public float Unknown634;     // offset: 1588, sz: 4, origin: 1036831949, parsed: 0.1        // line:   *(_DWORD *)(v1 + 1588) = 1036831949;
+        public float Unknown638;     // offset: 1592, sz: 4, origin: 1082130432, parsed: 4        // line:   *(_DWORD *)(v1 + 1592) = 1082130432;
+        public float Unknown63C;     // offset: 1596, sz: 4, origin: 1077936128, parsed: 3        // line:   *(_DWORD *)(v1 + 1596) = 1077936128;
+        public float Unknown640;     // offset: 1600, sz: 4, origin: 1084227584, parsed: 5        // line:   *(_DWORD *)(v1 + 1600) = 1084227584;
+        public float Unknown644;     // offset: 1604, sz: 4, origin: 1067030938, parsed: 1.2        // line:   *(_DWORD *)(v1 + 1604) = 1067030938;
+        public float Unknown648;     // offset: 1608, sz: 4, origin: 1061158912, parsed: 0.75        // line:   *(_DWORD *)(v1 + 1608) = 1061158912;
+
+        // missing 4 bytes at offset 1608
+        // could be padding, a undefined subroutine or a pointer accessing larger memory
+        [NMS(Size = 0x4, Ignore = true)]
+        public byte[] Padding64C;        // offset: 1612, sz: 4, comment: auto padding 
+
+        public long Unknown650;     // offset: 1616, sz: 8, origin: 0i64, parsed: 0. comment: aligned to 8 bytes! a long. two floats or two ints?        // line:   *(_QWORD *)(v1 + 1616) = 0i64;
+        public float Unknown658;     // offset: 1624, sz: 4, origin: 0, parsed: 0        // line:   *(_DWORD *)(v1 + 1624) = 0;
+
+        // missing 4 bytes at offset 1624
+        // could be padding, a undefined subroutine or a pointer accessing larger memory
+        [NMS(Size = 0x4, Ignore = true)]
+        public byte[] Padding65C;        // offset: 1628, sz: 4, comment: auto padding 
+
+        public float Unknown660;     // offset: 1632, sz: 4, origin: 1077936128, parsed: 3        // line:   *(_DWORD *)(v1 + 1632) = 1077936128;
+        public float Unknown664;     // offset: 1636, sz: 4, origin: 1086324736, parsed: 6        // line:   *(_DWORD *)(v1 + 1636) = 1086324736;
+        public float Unknown668;     // offset: 1640, sz: 4, origin: 1058642330, parsed: 0.6        // line:   *(_DWORD *)(v1 + 1640) = 1058642330;
+        public float Unknown66C;     // offset: 1644, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(v1 + 1644) = 1065353216;
+        public float Unknown670;     // offset: 1648, sz: 4, origin: 1045220557, parsed: 0.2        // line:   *(_DWORD *)(v1 + 1648) = 1045220557;
+        public float Unknown674;     // offset: 1652, sz: 4, origin: 1045220557, parsed: 0.2        // line:   *(_DWORD *)(v1 + 1652) = 1045220557;
+        public float Unknown678;     // offset: 1656, sz: 4, origin: 1056964608i64, parsed: 0.5, comment: unaligned to 8 bytes! two packed floats in a QWORD?(1)
+        public float Unknown67C;     // offset: 1660, sz: 4, origin: 1056964608i64, parsed: 0, comment: unaligned to 8 bytes! two packed floats in a QWORD?(2)        // line:   *(_QWORD *)(v1 + 1656) = 1056964608i64;
+        public float Unknown680;     // offset: 1664, sz: 4, origin: 1056964608, parsed: 0.5        // line:   *(_DWORD *)(v1 + 1664) = 1056964608;
+        public float Unknown684;     // offset: 1668, sz: 4, origin: 1039516303, parsed: 0.12        // line:   *(_DWORD *)(v1 + 1668) = 1039516303;
+        public float Unknown688;     // offset: 1672, sz: 4, origin: 1053609165, parsed: 0.4        // line:   *(_DWORD *)(v1 + 1672) = 1053609165;
+        public float Unknown68C;     // offset: 1676, sz: 4, origin: 1061997773, parsed: 0.8        // line:   *(_DWORD *)(v1 + 1676) = 1061997773;
+        public int Unknown690;     // offset: 1680, sz: 4, origin: 64, parsed: 64        // line:   *(_DWORD *)(v1 + 1680) = 64;
+        public float Unknown694;     // offset: 1684, sz: 4, origin: 1149239296, parsed: 1024        // line:   *(_DWORD *)(v1 + 1684) = 1149239296;
+        public float Unknown698;     // offset: 1688, sz: 4, origin: 1140850688, parsed: 512        // line:   *(_DWORD *)(v1 + 1688) = 1140850688;
+        public float Unknown69C;     // offset: 1692, sz: 4, origin: 1045220557, parsed: 0.2        // line:   *(_DWORD *)(v1 + 1692) = 1045220557;
+        public float Unknown6A0;     // offset: 1696, sz: 4, origin: 1083808154, parsed: 4.8        // line:   *(_DWORD *)(v1 + 1696) = 1083808154;
+        public float Unknown6A4;     // offset: 1700, sz: 4, origin: 1103626240, parsed: 25        // line:   *(_DWORD *)(v1 + 1700) = 1103626240;
+        public float Unknown6A8;     // offset: 1704, sz: 4, origin: 1077936128i64, parsed: 3, comment: unaligned to 8 bytes! two packed floats in a QWORD?(1)
+        public float Unknown6AC;     // offset: 1708, sz: 4, origin: 1077936128i64, parsed: 0, comment: unaligned to 8 bytes! two packed floats in a QWORD?(2)        // line:   *(_QWORD *)(v1 + 1704) = 1077936128i64;
+        public float Unknown6B0;     // offset: 1712, sz: 4, origin: 1097859072, parsed: 15        // line:   *(_DWORD *)(v1 + 1712) = 1097859072;
+        public float Unknown6B4;     // offset: 1716, sz: 4, origin: 1092616192, parsed: 10        // line:   *(_DWORD *)(v1 + 1716) = 1092616192;
+        public float Unknown6B8;     // offset: 1720, sz: 4, origin: 1056964608, parsed: 0.5        // line:   *(_DWORD *)(v1 + 1720) = 1056964608;
+        public float Unknown6BC;     // offset: 1724, sz: 4, origin: 1008981770, parsed: 0.01        // line:   *(_DWORD *)(v1 + 1724) = 1008981770;
+        public float Unknown6C0;     // offset: 1728, sz: 4, origin: 1036831949, parsed: 0.1        // line:   *(_DWORD *)(v1 + 1728) = 1036831949;
+        public float Unknown6C4;     // offset: 1732, sz: 4, origin: 1069547520, parsed: 1.5        // line:   *(_DWORD *)(v1 + 1732) = 1069547520;
+        public float Unknown6C8;     // offset: 1736, sz: 4, origin: 1036831949, parsed: 0.1        // line:   *(_DWORD *)(v1 + 1736) = 1036831949;
+        public float Unknown6CC;     // offset: 1740, sz: 4, origin: 1036831949, parsed: 0.1        // line:   *(_DWORD *)(v1 + 1740) = 1036831949;
+        public float Unknown6D0;     // offset: 1744, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(v1 + 1744) = 1065353216;
+        public float Unknown6D4;     // offset: 1748, sz: 4, origin: 1092616192, parsed: 10        // line:   *(_DWORD *)(v1 + 1748) = 1092616192;
+        public float Unknown6D8;     // offset: 1752, sz: 4, origin: 1097859072, parsed: 15        // line:   *(_DWORD *)(v1 + 1752) = 1097859072;
+        public float Unknown6DC;     // offset: 1756, sz: 4, origin: 1039516303, parsed: 0.12        // line:   *(_DWORD *)(v1 + 1756) = 1039516303;
+        public float Unknown6E0;     // offset: 1760, sz: 4, origin: 1084227584, parsed: 5        // line:   *(_DWORD *)(v1 + 1760) = 1084227584;
+        public float Unknown6E4;     // offset: 1764, sz: 4, origin: 1053609165, parsed: 0.4        // line:   *(_DWORD *)(v1 + 1764) = 1053609165;
+        public float Unknown6E8;     // offset: 1768, sz: 4, origin: 1128792064, parsed: 200        // line:   *(_DWORD *)(v1 + 1768) = 1128792064;
+        public float Unknown6EC;     // offset: 1772, sz: 4, origin: 1117126656, parsed: 75        // line:   *(_DWORD *)(v1 + 1772) = 1117126656;
+        public float Unknown6F0;     // offset: 1776, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(v1 + 1776) = 1065353216;
+        public float Unknown6F4;     // offset: 1780, sz: 4, origin: 1097859072, parsed: 15        // line:   *(_DWORD *)(v1 + 1780) = 1097859072;
+        public float Unknown6F8;     // offset: 1784, sz: 4, origin: 1097859072, parsed: 15        // line:   *(_DWORD *)(v1 + 1784) = 1097859072;
+        public float Unknown6FC;     // offset: 1788, sz: 4, origin: 1056964608, parsed: 0.5        // line:   *(_DWORD *)(v1 + 1788) = 1056964608;
+        public float Unknown700;     // offset: 1792, sz: 4, origin: 1084227584, parsed: 5        // line:   *(_DWORD *)(v1 + 1792) = 1084227584;
+        public float Unknown704;     // offset: 1796, sz: 4, origin: 1099956224, parsed: 18        // line:   *(_DWORD *)(v1 + 1796) = 1099956224;
+        public float Unknown708;     // offset: 1800, sz: 4, origin: 1090519040, parsed: 8        // line:   *(_DWORD *)(v1 + 1800) = 1090519040;
+        public float Unknown70C;     // offset: 1804, sz: 4, origin: 1061997773, parsed: 0.8        // line:   *(_DWORD *)(v1 + 1804) = 1061997773;
+        public float Unknown710;     // offset: 1808, sz: 4, origin: 1120403456, parsed: 100        // line:   *(_DWORD *)(v1 + 1808) = 1120403456;
+        public float Unknown714;     // offset: 1812, sz: 4, origin: 1061997773, parsed: 0.8        // line:   *(_DWORD *)(v1 + 1812) = 1061997773;
+        public float Unknown718;     // offset: 1816, sz: 4, origin: 1053609165, parsed: 0.4        // line:   *(_DWORD *)(v1 + 1816) = 1053609165;
+        public int Unknown71C;     // offset: 1820, sz: 4, origin: 500, parsed: 500        // line:   *(_DWORD *)(v1 + 1820) = 500;
+        public int Unknown720;     // offset: 1824, sz: 4, origin: 360, parsed: 360        // line:   *(_DWORD *)(v1 + 1824) = 360;
+        public float Unknown724;     // offset: 1828, sz: 4, origin: 1101004800, parsed: 20        // line:   *(_DWORD *)(v1 + 1828) = 1101004800;
+        public float Unknown728;     // offset: 1832, sz: 4, origin: 1082130432, parsed: 4        // line:   *(_DWORD *)(v1 + 1832) = 1082130432;
+        public float Unknown72C;     // offset: 1836, sz: 4, origin: 1112014848, parsed: 50        // line:   *(_DWORD *)(v1 + 1836) = 1112014848;
+        public float Unknown730;     // offset: 1840, sz: 4, origin: 1036831949, parsed: 0.1        // line:   *(_DWORD *)(v1 + 1840) = 1036831949;
+        public float Unknown734;     // offset: 1844, sz: 4, origin: -1093874483, parsed: -0.4        // line:   *(_DWORD *)(v1 + 1844) = -1093874483;
+        public float Unknown738;     // offset: 1848, sz: 4, origin: -1079613850, parsed: -1.3        // line:   *(_DWORD *)(v1 + 1848) = -1079613850;
+        public float Unknown73C;     // offset: 1852, sz: 4, origin: 0x40000000i64, parsed: 2, comment: unaligned to 8 bytes! two packed floats in a QWORD?(1)
+        public float Unknown740;     // offset: 1856, sz: 4, origin: 0x40000000i64, parsed: 0, comment: unaligned to 8 bytes! two packed floats in a QWORD?(2)        // line:   *(_QWORD *)(v1 + 1852) = 0x40000000i64;
+        public float Unknown744;     // offset: 1860, sz: 4, origin: -1090519040, parsed: -0.5        // line:   *(_DWORD *)(v1 + 1860) = -1090519040;
+        public float Unknown748;     // offset: 1864, sz: 4, origin: 1082130432, parsed: 4        // line:   *(_DWORD *)(v1 + 1864) = 1082130432;
+        public float Unknown74C;     // offset: 1868, sz: 4, origin: 1140457472, parsed: 500        // line:   *(_DWORD *)(v1 + 1868) = 1140457472;
+        public float Unknown750;     // offset: 1872, sz: 4, origin: 1084227584, parsed: 5        // line:   *(_DWORD *)(v1 + 1872) = 1084227584;
+        public float Unknown754;     // offset: 1876, sz: 4, origin: 1056964608, parsed: 0.5        // line:   *(_DWORD *)(v1 + 1876) = 1056964608;
+        public float Unknown758;     // offset: 1880, sz: 4, origin: 0x40000000, parsed: 2        // line:   *(_DWORD *)(v1 + 1880) = 0x40000000;
+        public float Unknown75C;     // offset: 1884, sz: 4, origin: 1082969293, parsed: 4.4        // line:   *(_DWORD *)(v1 + 1884) = 1082969293;
+        public float Unknown760;     // offset: 1888, sz: 4, origin: 1090519040, parsed: 8        // line:   *(_DWORD *)(v1 + 1888) = 1090519040;
+        public float Unknown764;     // offset: 1892, sz: 4, origin: 1056964608, parsed: 0.5        // line:   *(_DWORD *)(v1 + 1892) = 1056964608;
+        public float Unknown768;     // offset: 1896, sz: 4, origin: 1061997773, parsed: 0.8        // line:   *(_DWORD *)(v1 + 1896) = 1061997773;
+        public float Unknown76C;     // offset: 1900, sz: 4, origin: 1086324736, parsed: 6        // line:   *(_DWORD *)(v1 + 1900) = 1086324736;
+        public float Unknown770;     // offset: 1904, sz: 4, origin: 1084227584, parsed: 5        // line:   *(_DWORD *)(v1 + 1904) = 1084227584;
+        public float Unknown774;     // offset: 1908, sz: 4, origin: 1069547520, parsed: 1.5        // line:   *(_DWORD *)(v1 + 1908) = 1069547520;
+        public float Unknown778;     // offset: 1912, sz: 4, origin: 1082130432, parsed: 4        // line:   *(_DWORD *)(v1 + 1912) = 1082130432;
+        public float Unknown77C;     // offset: 1916, sz: 4, origin: 1083179008, parsed: 4.5        // line:   *(_DWORD *)(v1 + 1916) = 1083179008;
+        public float Unknown780;     // offset: 1920, sz: 4, origin: 1028443341, parsed: 0.05        // line:   *(_DWORD *)(v1 + 1920) = 1028443341;
+        public float Unknown784;     // offset: 1924, sz: 4, origin: 1036831949, parsed: 0.1        // line:   *(_DWORD *)(v1 + 1924) = 1036831949;
+        public float Unknown788;     // offset: 1928, sz: 4, origin: 1112014848, parsed: 50        // line:   *(_DWORD *)(v1 + 1928) = 1112014848;
+        public float Unknown78C;     // offset: 1932, sz: 4, origin: 1075838976, parsed: 2.5        // line:   *(_DWORD *)(v1 + 1932) = 1075838976;
+        public float Unknown790;     // offset: 1936, sz: 4, origin: 1118961664, parsed: 89        // line:   *(_DWORD *)(v1 + 1936) = 1118961664;
+        public float Unknown794;     // offset: 1940, sz: 4, origin: 1053609165, parsed: 0.4        // line:   *(_DWORD *)(v1 + 1940) = 1053609165;
+        public float Unknown798;     // offset: 1944, sz: 4, origin: 1045220557, parsed: 0.2        // line:   *(_DWORD *)(v1 + 1944) = 1045220557;
+        public float Unknown79C;     // offset: 1948, sz: 4, origin: 1106247680, parsed: 30        // line:   *(_DWORD *)(v1 + 1948) = 1106247680;
+        public float Unknown7A0;     // offset: 1952, sz: 4, origin: 1109393408, parsed: 40        // line:   *(_DWORD *)(v1 + 1952) = 1109393408;
+        public float Unknown7A4;     // offset: 1956, sz: 4, origin: 1123024896, parsed: 120        // line:   *(_DWORD *)(v1 + 1956) = 1123024896;
+        public float Unknown7A8;     // offset: 1960, sz: 4, origin: 1109393408, parsed: 40        // line:   *(_DWORD *)(v1 + 1960) = 1109393408;
+        public float Unknown7AC;     // offset: 1964, sz: 4, origin: 1108082688, parsed: 35        // line:   *(_DWORD *)(v1 + 1964) = 1108082688;
+        public float Unknown7B0;     // offset: 1968, sz: 4, origin: 1108082688, parsed: 35        // line:   *(_DWORD *)(v1 + 1968) = 1108082688;
+        public float Unknown7B4;     // offset: 1972, sz: 4, origin: 1053609165, parsed: 0.4        // line:   *(_DWORD *)(v1 + 1972) = 1053609165;
+        public float Unknown7B8;     // offset: 1976, sz: 4, origin: 1028443341, parsed: 0.05        // line:   *(_DWORD *)(v1 + 1976) = 1028443341;
+        public float Unknown7BC;     // offset: 1980, sz: 4, origin: 1097859072, parsed: 15        // line:   *(_DWORD *)(v1 + 1980) = 1097859072;
+        public float Unknown7C0;     // offset: 1984, sz: 4, origin: 1056964608, parsed: 0.5        // line:   *(_DWORD *)(v1 + 1984) = 1056964608;
+        public float Unknown7C4;     // offset: 1988, sz: 4, origin: 1084227584, parsed: 5        // line:   *(_DWORD *)(v1 + 1988) = 1084227584;
+        public float Unknown7C8;     // offset: 1992, sz: 4, origin: 1106247680, parsed: 30        // line:   *(_DWORD *)(v1 + 1992) = 1106247680;
+        public float Unknown7CC;     // offset: 1996, sz: 4, origin: 1106247680, parsed: 30        // line:   *(_DWORD *)(v1 + 1996) = 1106247680;
+        public float Unknown7D0;     // offset: 2000, sz: 4, origin: 1114636288, parsed: 60        // line:   *(_DWORD *)(v1 + 2000) = 1114636288;
+        public float Unknown7D4;     // offset: 2004, sz: 4, origin: 1053609165, parsed: 0.4        // line:   *(_DWORD *)(v1 + 2004) = 1053609165;
+        public float Unknown7D8;     // offset: 2008, sz: 4, origin: 1082130432, parsed: 4        // line:   *(_DWORD *)(v1 + 2008) = 1082130432;
+        public float Unknown7DC;     // offset: 2012, sz: 4, origin: 1086324736, parsed: 6        // line:   *(_DWORD *)(v1 + 2012) = 1086324736;
+        public float Unknown7E0;     // offset: 2016, sz: 4, origin: 1090519040, parsed: 8        // line:   *(_DWORD *)(v1 + 2016) = 1090519040;
+        public float Unknown7E4;     // offset: 2020, sz: 4, origin: 1056964608, parsed: 0.5        // line:   *(_DWORD *)(v1 + 2020) = 1056964608;
+        public float Unknown7E8;     // offset: 2024, sz: 4, origin: 1036831949, parsed: 0.1        // line:   *(_DWORD *)(v1 + 2024) = 1036831949;
+        public float Unknown7EC;     // offset: 2028, sz: 4, origin: 1017370378, parsed: 0.02        // line:   *(_DWORD *)(v1 + 2028) = 1017370378;
+        public float Unknown7F0;     // offset: 2032, sz: 4, origin: 1028443341, parsed: 0.05        // line:   *(_DWORD *)(v1 + 2032) = 1028443341;
+        public float Unknown7F4;     // offset: 2036, sz: 4, origin: 1017370378, parsed: 0.02        // line:   *(_DWORD *)(v1 + 2036) = 1017370378;
+        public float Unknown7F8;     // offset: 2040, sz: 4, origin: 1045220557, parsed: 0.2        // line:   *(_DWORD *)(v1 + 2040) = 1045220557;
+        public float Unknown7FC;     // offset: 2044, sz: 4, origin: 1035489772, parsed: 0.09        // line:   *(_DWORD *)(v1 + 2044) = 1035489772;
+        public float Unknown800;     // offset: 2048, sz: 4, origin: 1120403456, parsed: 100        // line:   *(_DWORD *)(v1 + 2048) = 1120403456;
+        public float Unknown804;     // offset: 2052, sz: 4, origin: 1045220557, parsed: 0.2        // line:   *(_DWORD *)(v1 + 2052) = 1045220557;
+        public float Unknown808;     // offset: 2056, sz: 4, origin: 1092616192, parsed: 10        // line:   *(_DWORD *)(v1 + 2056) = 1092616192;
+        public float Unknown80C;     // offset: 2060, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(v1 + 2060) = 1065353216;
+        public float Unknown810;     // offset: 2064, sz: 4, origin: 1028443341, parsed: 0.05        // line:   *(_DWORD *)(v1 + 2064) = 1028443341;
+        public float Unknown814;     // offset: 2068, sz: 4, origin: 0x40000000, parsed: 2        // line:   *(_DWORD *)(v1 + 2068) = 0x40000000;
+        public float Unknown818;     // offset: 2072, sz: 4, origin: 1077936128, parsed: 3        // line:   *(_DWORD *)(v1 + 2072) = 1077936128;
+        public float Unknown81C;     // offset: 2076, sz: 4, origin: 1106247680, parsed: 30        // line:   *(_DWORD *)(v1 + 2076) = 1106247680;
+        public float Unknown820;     // offset: 2080, sz: 4, origin: 1090519040, parsed: 8        // line:   *(_DWORD *)(v1 + 2080) = 1090519040;
+        public float Unknown824;     // offset: 2084, sz: 4, origin: 1077936128, parsed: 3        // line:   *(_DWORD *)(v1 + 2084) = 1077936128;
+        public float Unknown828;     // offset: 2088, sz: 4, origin: 1064514355, parsed: 0.95        // line:   *(_DWORD *)(v1 + 2088) = 1064514355;
+        public float Unknown82C;     // offset: 2092, sz: 4, origin: 1045220557, parsed: 0.2        // line:   *(_DWORD *)(v1 + 2092) = 1045220557;
+        public float Unknown830;     // offset: 2096, sz: 4, origin: 1000593162, parsed: 0.005        // line:   *(_DWORD *)(v1 + 2096) = 1000593162;
+        public float Unknown834;     // offset: 2100, sz: 4, origin: 1097859072, parsed: 15        // line:   *(_DWORD *)(v1 + 2100) = 1097859072;
+        public float Unknown838;     // offset: 2104, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(v1 + 2104) = 1065353216;
+        public float Unknown83C;     // offset: 2108, sz: 4, origin: 1084227584, parsed: 5        // line:   *(_DWORD *)(v1 + 2108) = 1084227584;
+        public float Unknown840;     // offset: 2112, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(v1 + 2112) = 1065353216;
+        public int Unknown844;     // offset: 2116, sz: 4, origin: 5, parsed: 5        // line:   *(_DWORD *)(v1 + 2116) = 5;
+        public float Unknown848;     // offset: 2120, sz: 4, origin: 1056964608, parsed: 0.5        // line:   *(_DWORD *)(v1 + 2120) = 1056964608;
+        public float Unknown84C;     // offset: 2124, sz: 4, origin: 1084227584, parsed: 5        // line:   *(_DWORD *)(v1 + 2124) = 1084227584;
+        public float Unknown850;     // offset: 2128, sz: 4, origin: 0x40000000, parsed: 2        // line:   *(_DWORD *)(v1 + 2128) = 0x40000000;
+        public float Unknown854;     // offset: 2132, sz: 4, origin: 1101004800, parsed: 20        // line:   *(_DWORD *)(v1 + 2132) = 1101004800;
+        public bool Unknown858;     // offset: 2136, sz: 1, origin: 0, parsed: 0        // line:   *(_BYTE *)(v1 + 2136) = 0;
+
+        // missing 3 bytes at offset 2136
+        // does 2136 contain a DWORD?
+        [NMS(Size = 0x3, Ignore = true)]
+        public byte[] Padding859;        // offset: 2137, sz: 3, comment: auto padding 
+
+        public float Unknown85C;     // offset: 2140, sz: 4, origin: 1072064102, parsed: 1.8        // line:   *(_DWORD *)(v1 + 2140) = 1072064102;
+        public float Unknown860;     // offset: 2144, sz: 4, origin: 1086324736, parsed: 6        // line:   *(_DWORD *)(v1 + 2144) = 1086324736;
+        public float Unknown864;     // offset: 2148, sz: 4, origin: 1101004800, parsed: 20        // line:   *(_DWORD *)(v1 + 2148) = 1101004800;
+        public bool Unknown868;     // offset: 2152, sz: 1, origin: 0, parsed: 0        // line:   *(_BYTE *)(v1 + 2152) = 0;
+
+        // missing 3 bytes at offset 2152
+        // does 2152 contain a DWORD?
+        [NMS(Size = 0x3, Ignore = true)]
+        public byte[] Padding869;        // offset: 2153, sz: 3, comment: auto padding 
+
+        public float Unknown86C;     // offset: 2156, sz: 4, origin: 1072064102, parsed: 1.8        // line:   *(_DWORD *)(v1 + 2156) = 1072064102;
+        public float Unknown870;     // offset: 2160, sz: 4, origin: 1086324736, parsed: 6        // line:   *(_DWORD *)(v1 + 2160) = 1086324736;
+        public float Unknown874;     // offset: 2164, sz: 4, origin: 1106247680, parsed: 30        // line:   *(_DWORD *)(v1 + 2164) = 1106247680;
+        public float Unknown878;     // offset: 2168, sz: 4, origin: 1109393408, parsed: 40        // line:   *(_DWORD *)(v1 + 2168) = 1109393408;
+        public float Unknown87C;     // offset: 2172, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(v1 + 2172) = 1065353216;
+        public float Unknown880;     // offset: 2176, sz: 4, origin: 0x40000000, parsed: 2        // line:   *(_DWORD *)(v1 + 2176) = 0x40000000;
+        public float Unknown884;     // offset: 2180, sz: 4, origin: 1067030938, parsed: 1.2        // line:   *(_DWORD *)(v1 + 2180) = 1067030938;
+        public float Unknown888;     // offset: 2184, sz: 4, origin: 1135542272, parsed: 350        // line:   *(_DWORD *)(v1 + 2184) = 1135542272;
+        public float Unknown88C;     // offset: 2188, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(v1 + 2188) = 1065353216;
+        public float Unknown890;     // offset: 2192, sz: 4, origin: 1106247680, parsed: 30        // line:   *(_DWORD *)(v1 + 2192) = 1106247680;
+        public float Unknown894;     // offset: 2196, sz: 4, origin: 1109393408, parsed: 40        // line:   *(_DWORD *)(v1 + 2196) = 1109393408;
+        public float Unknown898;     // offset: 2200, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(v1 + 2200) = 1065353216;
+        public float Unknown89C;     // offset: 2204, sz: 4, origin: 0x40000000, parsed: 2        // line:   *(_DWORD *)(v1 + 2204) = 0x40000000;
+        public float Unknown8A0;     // offset: 2208, sz: 4, origin: 1067030938, parsed: 1.2        // line:   *(_DWORD *)(v1 + 2208) = 1067030938;
+        public float Unknown8A4;     // offset: 2212, sz: 4, origin: 1135542272, parsed: 350        // line:   *(_DWORD *)(v1 + 2212) = 1135542272;
+        public float Unknown8A8;     // offset: 2216, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(v1 + 2216) = 1065353216;
+        public float Unknown8AC;     // offset: 2220, sz: 4, origin: 1092616192, parsed: 10        // line:   *(_DWORD *)(v1 + 2220) = 1092616192;
+        public float Unknown8B0;     // offset: 2224, sz: 4, origin: 1112014848, parsed: 50        // line:   *(_DWORD *)(v1 + 2224) = 1112014848;
+        public float Unknown8B4;     // offset: 2228, sz: 4, origin: 1103626240, parsed: 25        // line:   *(_DWORD *)(v1 + 2228) = 1103626240;
+        public float Unknown8B8;     // offset: 2232, sz: 4, origin: 0x40000000, parsed: 2        // line:   *(_DWORD *)(v1 + 2232) = 0x40000000;
+        public float Unknown8BC;     // offset: 2236, sz: 4, origin: 1065353216i64, parsed: 1, comment: unaligned to 8 bytes! two packed floats in a QWORD?(1)
+        public float Unknown8C0;     // offset: 2240, sz: 4, origin: 1065353216i64, parsed: 0, comment: unaligned to 8 bytes! two packed floats in a QWORD?(2)        // line:   *(_QWORD *)(v1 + 2236) = 1065353216i64;
+        public float Unknown8C4;     // offset: 2244, sz: 4, origin: 1259902591, parsed: 9999999        // line:   *(_DWORD *)(v1 + 2244) = 1259902591;
+        public float Unknown8C8;     // offset: 2248, sz: 4, origin: 1091567616, parsed: 9        // line:   *(_DWORD *)(v1 + 2248) = 1091567616;
+
+        // missing 4 bytes at offset 2248
+        // could be padding, a undefined subroutine or a pointer accessing larger memory
+        [NMS(Size = 0x4, Ignore = true)]
+        public byte[] Padding8CC;        // offset: 2252, sz: 4, comment: auto padding 
+
+        public long Unknown8D0;     // offset: 2256, sz: 8, origin: 0i64, parsed: 0. comment: aligned to 8 bytes! a long. two floats or two ints?        // line:   *(_QWORD *)(v1 + 2256) = 0i64;
+        public float Unknown8D8;     // offset: 2264, sz: 4, origin: 1065353216i64, parsed: 1, comment: unaligned to 8 bytes! two packed floats in a QWORD?(1)
+        public float Unknown8DC;     // offset: 2268, sz: 4, origin: 1065353216i64, parsed: 0, comment: unaligned to 8 bytes! two packed floats in a QWORD?(2)        // line:   *(_QWORD *)(v1 + 2264) = 1065353216i64;
+        public float Unknown8E0;     // offset: 2272, sz: 4, origin: 0, parsed: 0        // line:   *(_DWORD *)(v1 + 2272) = 0;
+        public float Unknown8E4;     // offset: 2276, sz: 4, origin: 1065353216i64, parsed: 1, comment: unaligned to 8 bytes! two packed floats in a QWORD?(1)
+        public float Unknown8E8;     // offset: 2280, sz: 4, origin: 1065353216i64, parsed: 0, comment: unaligned to 8 bytes! two packed floats in a QWORD?(2)        // line:   *(_QWORD *)(v1 + 2276) = 1065353216i64; // moved  
+        public float Unknown8EC;     // offset: 2284, sz: 4, origin: 0, parsed: 0        // line:   *(_DWORD *)(v1 + 2284) = 0;  
+        public float Unknown8F0;     // offset: 2288, sz: 4, origin: 1148846080i64, parsed: 1000, comment: unaligned to 8 bytes! two packed floats in a QWORD?(1)
+        public float Unknown8F4;     // offset: 2292, sz: 4, origin: 1148846080i64, parsed: 0, comment: unaligned to 8 bytes! two packed floats in a QWORD?(2)        // line:   *(_QWORD *)(v1 + 2288) = 1148846080i64;
+        public float Unknown8F8;     // offset: 2296, sz: 4, origin: 1148846080i64, parsed: 1000, comment: unaligned to 8 bytes! two packed floats in a QWORD?(1)
+        public float Unknown8FC;     // offset: 2300, sz: 4, origin: 1148846080i64, parsed: 0, comment: unaligned to 8 bytes! two packed floats in a QWORD?(2)        // line:   *(_QWORD *)(v1 + 2296) = 1148846080i64;
+        public long Unknown900;     // offset: 2304, sz: 8, origin: 0i64, parsed: 0. comment: aligned to 8 bytes! a long. two floats or two ints?        // line:   *(_QWORD *)(v1 + 2304) = 0i64;
+        public float Unknown908;     // offset: 2312, sz: 4, origin: 1065353216i64, parsed: 1, comment: unaligned to 8 bytes! two packed floats in a QWORD?(1)
+        public float Unknown90C;     // offset: 2316, sz: 4, origin: 1065353216i64, parsed: 0, comment: unaligned to 8 bytes! two packed floats in a QWORD?(2)        // line:   *(_QWORD *)(v1 + 2312) = 1065353216i64;
+        public long Unknown910;     // offset: 2320, sz: 8, origin: 0i64, parsed: 0. comment: aligned to 8 bytes! a long. two floats or two ints?        // line:   *(_QWORD *)(v1 + 2320) = 0i64;
+        public float Unknown918;     // offset: 2328, sz: 4, origin: 1065353216i64, parsed: 1, comment: unaligned to 8 bytes! two packed floats in a QWORD?(1)
+        public float Unknown91C;     // offset: 2332, sz: 4, origin: 1065353216i64, parsed: 0, comment: unaligned to 8 bytes! two packed floats in a QWORD?(2)        // line:   *(_QWORD *)(v1 + 2328) = 1065353216i64;
+        public float Unknown920;     // offset: 2336, sz: 4, origin: 0, parsed: 0        // line:   *(_DWORD *)(v1 + 2336) = 0;
+        public float Unknown924;     // offset: 2340, sz: 4, origin: 1065353216i64, parsed: 1, comment: unaligned to 8 bytes! two packed floats in a QWORD?(1)
+        public float Unknown928;     // offset: 2344, sz: 4, origin: 1065353216i64, parsed: 0, comment: unaligned to 8 bytes! two packed floats in a QWORD?(2)        // line:   *(_QWORD *)(v1 + 2340) = 1065353216i64; // moved  
+        public float Unknown92C;     // offset: 2348, sz: 4, origin: 0, parsed: 0        // line:   *(_DWORD *)(v1 + 2348) = 0;  
+        public float Unknown930;     // offset: 2352, sz: 4, origin: 1148846080i64, parsed: 1000, comment: unaligned to 8 bytes! two packed floats in a QWORD?(1)
+        public float Unknown934;     // offset: 2356, sz: 4, origin: 1148846080i64, parsed: 0, comment: unaligned to 8 bytes! two packed floats in a QWORD?(2)        // line:   *(_QWORD *)(v1 + 2352) = 1148846080i64;
+        public float Unknown938;     // offset: 2360, sz: 4, origin: 1148846080i64, parsed: 1000, comment: unaligned to 8 bytes! two packed floats in a QWORD?(1)
+        public float Unknown93C;     // offset: 2364, sz: 4, origin: 1148846080i64, parsed: 0, comment: unaligned to 8 bytes! two packed floats in a QWORD?(2)        // line:   *(_QWORD *)(v1 + 2360) = 1148846080i64;
+        public long Unknown940;     // offset: 2368, sz: 8, origin: 0i64, parsed: 0. comment: aligned to 8 bytes! a long. two floats or two ints?        // line:   *(_QWORD *)(v1 + 2368) = 0i64;
+        public float Unknown948;     // offset: 2376, sz: 4, origin: 1065353216i64, parsed: 1, comment: unaligned to 8 bytes! two packed floats in a QWORD?(1)
+        public float Unknown94C;     // offset: 2380, sz: 4, origin: 1065353216i64, parsed: 0, comment: unaligned to 8 bytes! two packed floats in a QWORD?(2)        // line:   *(_QWORD *)(v1 + 2376) = 1065353216i64;
+        public long Unknown950;     // offset: 2384, sz: 8, origin: 0i64, parsed: 0. comment: aligned to 8 bytes! a long. two floats or two ints?        // line:   *(_QWORD *)(v1 + 2384) = 0i64;
+        public float Unknown958;     // offset: 2392, sz: 4, origin: 1065353216i64, parsed: 1, comment: unaligned to 8 bytes! two packed floats in a QWORD?(1)
+        public float Unknown95C;     // offset: 2396, sz: 4, origin: 1065353216i64, parsed: 0, comment: unaligned to 8 bytes! two packed floats in a QWORD?(2)        // line:   *(_QWORD *)(v1 + 2392) = 1065353216i64;
+        public float Unknown960;     // offset: 2400, sz: 4, origin: 0, parsed: 0        // line:   *(_DWORD *)(v1 + 2400) = 0;  
+        public float Unknown964;     // offset: 2404, sz: 4, origin: 1065353216i64, parsed: 1, comment: unaligned to 8 bytes! two packed floats in a QWORD?(1)
+        public float Unknown968;     // offset: 2408, sz: 4, origin: 1065353216i64, parsed: 0, comment: unaligned to 8 bytes! two packed floats in a QWORD?(2)        // line:   *(_QWORD *)(v1 + 2404) = 1065353216i64;
+        public float Unknown96C;     // offset: 2412, sz: 4, origin: 0, parsed: 0        // line:   *(_DWORD *)(v1 + 2412) = 0; // moved  
+        public float Unknown970;     // offset: 2416, sz: 4, origin: 1148846080i64, parsed: 1000, comment: unaligned to 8 bytes! two packed floats in a QWORD?(1)
+        public float Unknown974;     // offset: 2420, sz: 4, origin: 1148846080i64, parsed: 0, comment: unaligned to 8 bytes! two packed floats in a QWORD?(2)        // line:   *(_QWORD *)(v1 + 2416) = 1148846080i64;
+        public float Unknown978;     // offset: 2424, sz: 4, origin: 1148846080i64, parsed: 1000, comment: unaligned to 8 bytes! two packed floats in a QWORD?(1)
+        public float Unknown97C;     // offset: 2428, sz: 4, origin: 1148846080i64, parsed: 0, comment: unaligned to 8 bytes! two packed floats in a QWORD?(2)        // line:   *(_QWORD *)(v1 + 2424) = 1148846080i64;
+        public long Unknown980;     // offset: 2432, sz: 8, origin: 0i64, parsed: 0. comment: aligned to 8 bytes! a long. two floats or two ints?        // line:   *(_QWORD *)(v1 + 2432) = 0i64;
+        public float Unknown988;     // offset: 2440, sz: 4, origin: 1065353216i64, parsed: 1, comment: unaligned to 8 bytes! two packed floats in a QWORD?(1)
+        public float Unknown98C;     // offset: 2444, sz: 4, origin: 1065353216i64, parsed: 0, comment: unaligned to 8 bytes! two packed floats in a QWORD?(2)        // line:   *(_QWORD *)(v1 + 2440) = 1065353216i64;
+        // line:   return result;
+        // line: }
+
+        // no end padding needed
+
+        // accumulated template size: 2448 (0x990)
+        // number of properties parsed: 531
+    }
+}

--- a/MBINCompiler/Models/Structs/Unfinished/GcUIGlobals.cs
+++ b/MBINCompiler/Models/Structs/Unfinished/GcUIGlobals.cs
@@ -1,0 +1,1172 @@
+// generated output for subroutine:
+// signed __int64 __fastcall raw_GcUIGlobals(__int64 a1) -----> hash: 21D52E2
+// hash of whole input: 8AEA2A75
+
+namespace MBINCompiler.Models.Structs
+{
+    public class GcUIGlobals : NMSTemplate // 0x3DE0
+    {
+        // generated with MBINRawTemplateParser
+
+        // line: signed __int64 __fastcall raw_GcUIGlobals(__int64 a1)
+        // line: {
+        // line:   // sub_140164930
+        // line:   __int64 v1; // rdi@1
+        // line:   signed __int64 result; // rax@1
+        // line:   signed __int64 v3; // rcx@1
+        public int Unknown0;     // offset: 0, sz: 4, origin: 2, parsed: 2        // line:   *(_DWORD *)a1 = 2;
+        public float Unknown4;     // offset: 4, sz: 4, origin: 1116209152, parsed: 68        // line:   *(_DWORD *)(a1 + 4) = 1116209152;
+
+        // missing 8 bytes at offset 4
+        // could be padding, a undefined subroutine or a pointer accessing larger memory
+        [NMS(Size = 0x8, Ignore = true)]
+        public byte[] Padding8;        // offset: 8, sz: 8, comment: auto padding 
+
+        public float Unknown10;     // offset: 16, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(a1 + 16) = 1065353216;
+        public float Unknown14;     // offset: 20, sz: 4, origin: 1039516303, parsed: 0.12        // line:   *(_DWORD *)(a1 + 20) = 1039516303;
+        public float Unknown18;     // offset: 24, sz: 4, origin: 1039516303, parsed: 0.12        // line:   *(_DWORD *)(a1 + 24) = 1039516303;
+        public float Unknown1C;     // offset: 28, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(a1 + 28) = 1065353216;
+        public float Unknown20;     // offset: 32, sz: 4, origin: 1053609165, parsed: 0.4        // line:   *(_DWORD *)(a1 + 32) = 1053609165;
+        public float Unknown24;     // offset: 36, sz: 4, origin: 1039516303, parsed: 0.12        // line:   *(_DWORD *)(a1 + 36) = 1039516303;
+        public float Unknown28;     // offset: 40, sz: 4, origin: 1039516303, parsed: 0.12        // line:   *(_DWORD *)(a1 + 40) = 1039516303;
+        public float Unknown2C;     // offset: 44, sz: 4, origin: 1060320051, parsed: 0.7        // line:   *(_DWORD *)(a1 + 44) = 1060320051;
+        public float Unknown30;     // offset: 48, sz: 4, origin: 1077936128, parsed: 3        // line:   *(_DWORD *)(a1 + 48) = 1077936128;
+        public int Unknown34;     // offset: 52, sz: 4, origin: 5, parsed: 5        // line:   *(_DWORD *)(a1 + 52) = 5;
+        public float Unknown38;     // offset: 56, sz: 4, origin: 1107820544, parsed: 34        // line:   *(_DWORD *)(a1 + 56) = 1107820544;
+        public float Unknown3C;     // offset: 60, sz: 4, origin: 1117782016, parsed: 80        // line:   *(_DWORD *)(a1 + 60) = 1117782016;
+        public float Unknown40;     // offset: 64, sz: 4, origin: 1111490560, parsed: 48        // line:   *(_DWORD *)(a1 + 64) = 1111490560;
+        public float Unknown44;     // offset: 68, sz: 4, origin: 1056964608, parsed: 0.5        // line:   *(_DWORD *)(a1 + 68) = 1056964608;
+        public float Unknown48;     // offset: 72, sz: 4, origin: 1084227584, parsed: 5        // line:   *(_DWORD *)(a1 + 72) = 1084227584;
+        public float Unknown4C;     // offset: 76, sz: 4, origin: 1105199104, parsed: 28        // line:   *(_DWORD *)(a1 + 76) = 1105199104;
+        public float Unknown50;     // offset: 80, sz: 4, origin: 1099956224, parsed: 18        // line:   *(_DWORD *)(a1 + 80) = 1099956224;
+        public float Unknown54;     // offset: 84, sz: 4, origin: 1107296256, parsed: 32        // line:   *(_DWORD *)(a1 + 84) = 1107296256;
+        public float Unknown58;     // offset: 88, sz: 4, origin: 1045220557, parsed: 0.2        // line:   *(_DWORD *)(a1 + 88) = 1045220557;
+        public float Unknown5C;     // offset: 92, sz: 4, origin: 1084227584, parsed: 5        // line:   *(_DWORD *)(a1 + 92) = 1084227584;
+        public float Unknown60;     // offset: 96, sz: 4, origin: 1045220557, parsed: 0.2        // line:   *(_DWORD *)(a1 + 96) = 1045220557;
+        public float Unknown64;     // offset: 100, sz: 4, origin: 1082130432, parsed: 4        // line:   *(_DWORD *)(a1 + 100) = 1082130432;
+        public float Unknown68;     // offset: 104, sz: 4, origin: 1058642330, parsed: 0.6        // line:   *(_DWORD *)(a1 + 104) = 1058642330;
+        public float Unknown6C;     // offset: 108, sz: 4, origin: 1116733440, parsed: 72        // line:   *(_DWORD *)(a1 + 108) = 1116733440;
+        public float Unknown70;     // offset: 112, sz: 4, origin: -1025769472, parsed: -110        // line:   *(_DWORD *)(a1 + 112) = -1025769472;
+        public float Unknown74;     // offset: 116, sz: 4, origin: 1109393408, parsed: 40        // line:   *(_DWORD *)(a1 + 116) = 1109393408;
+        public float Unknown78;     // offset: 120, sz: 4, origin: 1053609165, parsed: 0.4        // line:   *(_DWORD *)(a1 + 120) = 1053609165;
+        public float Unknown7C;     // offset: 124, sz: 4, origin: 1137180672, parsed: 400        // line:   *(_DWORD *)(a1 + 124) = 1137180672;
+        public float Unknown80;     // offset: 128, sz: 4, origin: 1120403456, parsed: 100        // line:   *(_DWORD *)(a1 + 128) = 1120403456;
+        public float Unknown84;     // offset: 132, sz: 4, origin: 1036831949, parsed: 0.1        // line:   *(_DWORD *)(a1 + 132) = 1036831949;
+        public float Unknown88;     // offset: 136, sz: 4, origin: 1069547520i64, parsed: 1.5, comment: unaligned to 8 bytes! two packed floats in a QWORD?(1)
+        public float Unknown8C;     // offset: 140, sz: 4, origin: 1069547520i64, parsed: 0, comment: unaligned to 8 bytes! two packed floats in a QWORD?(2)        // line:   *(_QWORD *)(a1 + 136) = 1069547520i64;
+        public float Unknown90;     // offset: 144, sz: 4, origin: -1021968384, parsed: -150        // line:   *(_DWORD *)(a1 + 144) = -1021968384;
+        public float Unknown94;     // offset: 148, sz: 4, origin: 1157234688, parsed: 2000        // line:   *(_DWORD *)(a1 + 148) = 1157234688;
+        public float Unknown98;     // offset: 152, sz: 4, origin: 1060320051, parsed: 0.7        // line:   *(_DWORD *)(a1 + 152) = 1060320051;
+        public float Unknown9C;     // offset: 156, sz: 4, origin: 1092616192, parsed: 10        // line:   *(_DWORD *)(a1 + 156) = 1092616192;
+        public float UnknownA0;     // offset: 160, sz: 4, origin: 1085276160, parsed: 5.5        // line:   *(_DWORD *)(a1 + 160) = 1085276160;
+        public float UnknownA4;     // offset: 164, sz: 4, origin: 1053609165i64, parsed: 0.4, comment: unaligned to 8 bytes! two packed floats in a QWORD?(1)
+        public float UnknownA8;     // offset: 168, sz: 4, origin: 1053609165i64, parsed: 0, comment: unaligned to 8 bytes! two packed floats in a QWORD?(2)        // line:   *(_QWORD *)(a1 + 164) = 1053609165i64;
+        public float UnknownAC;     // offset: 172, sz: 4, origin: 1086324736, parsed: 6        // line:   *(_DWORD *)(a1 + 172) = 1086324736;
+        public float UnknownB0;     // offset: 176, sz: 4, origin: 1109393408, parsed: 40        // line:   *(_DWORD *)(a1 + 176) = 1109393408;
+        public float UnknownB4;     // offset: 180, sz: 4, origin: 1067030938i64, parsed: 1.2, comment: unaligned to 8 bytes! two packed floats in a QWORD?(1)
+        public float UnknownB8;     // offset: 184, sz: 4, origin: 1067030938i64, parsed: 0, comment: unaligned to 8 bytes! two packed floats in a QWORD?(2)        // line:   *(_QWORD *)(a1 + 180) = 1067030938i64;
+        // line:   v1 = a1;
+        public float UnknownBC;     // offset: 188, sz: 4, origin: 0, parsed: 0        // line:   *(_DWORD *)(a1 + 188) = 0;
+        public float UnknownC0;     // offset: 192, sz: 4, origin: 1086324736, parsed: 6        // line:   *(_DWORD *)(a1 + 192) = 1086324736;
+        public float UnknownC4;     // offset: 196, sz: 4, origin: 1109393408, parsed: 40        // line:   *(_DWORD *)(a1 + 196) = 1109393408;
+        public float UnknownC8;     // offset: 200, sz: 4, origin: 1067030938i64, parsed: 1.2, comment: unaligned to 8 bytes! two packed floats in a QWORD?(1)
+        public float UnknownCC;     // offset: 204, sz: 4, origin: 1067030938i64, parsed: 0, comment: unaligned to 8 bytes! two packed floats in a QWORD?(2)        // line:   *(_QWORD *)(a1 + 200) = 1067030938i64;
+        public float UnknownD0;     // offset: 208, sz: 4, origin: 0, parsed: 0        // line:   *(_DWORD *)(a1 + 208) = 0;
+
+        // missing 12 bytes at offset 208
+        // could be padding, a undefined subroutine or a pointer accessing larger memory
+        [NMS(Size = 0xC, Ignore = true)]
+        public byte[] PaddingD4;        // offset: 212, sz: 12, comment: auto padding 
+
+        public float UnknownE0;     // offset: 224, sz: 4, origin: 1065353216i64, parsed: 1, comment: unaligned to 8 bytes! two packed floats in a QWORD?(1)
+        public float UnknownE4;     // offset: 228, sz: 4, origin: 1065353216i64, parsed: 0, comment: unaligned to 8 bytes! two packed floats in a QWORD?(2)        // line:   *(_QWORD *)(a1 + 224) = 1065353216i64;
+        public float UnknownE8;     // offset: 232, sz: 4, origin: 1025758986, parsed: 0.04        // line:   *(_DWORD *)(a1 + 232) = 1025758986;
+        public float UnknownEC;     // offset: 236, sz: 4, origin: 1056964608, parsed: 0.5        // line:   *(_DWORD *)(a1 + 236) = 1056964608;
+        public float UnknownF0;     // offset: 240, sz: 4, origin: 1063876821, parsed: 0.912        // line:   *(_DWORD *)(a1 + 240) = 1063876821;
+        public float UnknownF4;     // offset: 244, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(a1 + 244) = 1065353216;
+        public float UnknownF8;     // offset: 248, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(a1 + 248) = 1065353216;
+        public float UnknownFC;     // offset: 252, sz: 4, origin: 1056964608, parsed: 0.5        // line:   *(_DWORD *)(a1 + 252) = 1056964608;
+        public float Unknown100;     // offset: 256, sz: 4, origin: 1036831949, parsed: 0.1        // line:   *(_DWORD *)(a1 + 256) = 1036831949;
+        public float Unknown104;     // offset: 260, sz: 4, origin: 1056964608i64, parsed: 0.5, comment: unaligned to 8 bytes! two packed floats in a QWORD?(1)
+        public float Unknown108;     // offset: 264, sz: 4, origin: 1056964608i64, parsed: 0, comment: unaligned to 8 bytes! two packed floats in a QWORD?(2)        // line:   *(_QWORD *)(a1 + 260) = 1056964608i64;
+        public float Unknown10C;     // offset: 268, sz: 4, origin: 1056964608, parsed: 0.5        // line:   *(_DWORD *)(a1 + 268) = 1056964608;
+        public float Unknown110;     // offset: 272, sz: 4, origin: 1077936128, parsed: 3        // line:   *(_DWORD *)(a1 + 272) = 1077936128;
+        public int Unknown114;     // offset: 276, sz: 4, origin: 36, parsed: 36        // line:   *(_DWORD *)(a1 + 276) = 36;
+        public bool Unknown118;     // offset: 280, sz: 1, origin: 0, parsed: 0        // line:   *(_BYTE *)(a1 + 280) = 0;
+
+        // missing 3 bytes at offset 280
+        // does 280 contain a DWORD?
+        [NMS(Size = 0x3, Ignore = true)]
+        public byte[] Padding119;        // offset: 281, sz: 3, comment: auto padding 
+
+        public float Unknown11C;     // offset: 284, sz: 4, origin: 1086324736, parsed: 6        // line:   *(_DWORD *)(a1 + 284) = 1086324736;
+        public float Unknown120;     // offset: 288, sz: 4, origin: 1061158912, parsed: 0.75        // line:   *(_DWORD *)(a1 + 288) = 1061158912;
+        public float Unknown124;     // offset: 292, sz: 4, origin: -1027080192, parsed: -100        // line:   *(_DWORD *)(a1 + 292) = -1027080192;
+        public float Unknown128;     // offset: 296, sz: 4, origin: 1120403456, parsed: 100        // line:   *(_DWORD *)(a1 + 296) = 1120403456;
+        public float Unknown12C;     // offset: 300, sz: 4, origin: 1092616192, parsed: 10        // line:   *(_DWORD *)(a1 + 300) = 1092616192;
+        public float Unknown130;     // offset: 304, sz: 4, origin: 1125515264, parsed: 150        // line:   *(_DWORD *)(a1 + 304) = 1125515264;
+        public float Unknown134;     // offset: 308, sz: 4, origin: 1053609165, parsed: 0.4        // line:   *(_DWORD *)(a1 + 308) = 1053609165;
+        public float Unknown138;     // offset: 312, sz: 4, origin: 1123680256, parsed: 125        // line:   *(_DWORD *)(a1 + 312) = 1123680256;
+        public float Unknown13C;     // offset: 316, sz: 4, origin: 1106247680, parsed: 30        // line:   *(_DWORD *)(a1 + 316) = 1106247680;
+        public float Unknown140;     // offset: 320, sz: 4, origin: 1112014848, parsed: 50        // line:   *(_DWORD *)(a1 + 320) = 1112014848;
+        public float Unknown144;     // offset: 324, sz: 4, origin: 1114636288, parsed: 60        // line:   *(_DWORD *)(a1 + 324) = 1114636288;
+        public float Unknown148;     // offset: 328, sz: 4, origin: 1060320051, parsed: 0.7        // line:   *(_DWORD *)(a1 + 328) = 1060320051;
+        public float Unknown14C;     // offset: 332, sz: 4, origin: 1058642330, parsed: 0.6        // line:   *(_DWORD *)(a1 + 332) = 1058642330;
+        public float Unknown150;     // offset: 336, sz: 4, origin: 0x40000000, parsed: 2        // line:   *(_DWORD *)(a1 + 336) = 0x40000000;
+
+        // missing 12 bytes at offset 336
+        // could be padding, a undefined subroutine or a pointer accessing larger memory
+        [NMS(Size = 0xC, Ignore = true)]
+        public byte[] Padding154;        // offset: 340, sz: 12, comment: auto padding 
+
+        public float Unknown160;     // offset: 352, sz: 4, origin: 1020054733, parsed: 0.025        // line:   *(_DWORD *)(a1 + 352) = 1020054733;
+        public float Unknown164;     // offset: 356, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(a1 + 356) = 1065353216;
+        public float Unknown168;     // offset: 360, sz: 4, origin: 1039784739, parsed: 0.122        // line:   *(_DWORD *)(a1 + 360) = 1039784739;
+        public float Unknown16C;     // offset: 364, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(a1 + 364) = 1065353216;
+        public float Unknown170;     // offset: 368, sz: 4, origin: 1010055512, parsed: 0.011        // line:   *(_DWORD *)(a1 + 368) = 1010055512;
+        public float Unknown174;     // offset: 372, sz: 4, origin: 1061377016, parsed: 0.763        // line:   *(_DWORD *)(a1 + 372) = 1061377016;
+        public float Unknown178;     // offset: 376, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(a1 + 376) = 1065353216;
+        public float Unknown17C;     // offset: 380, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(a1 + 380) = 1065353216;
+        public float Unknown180;     // offset: 384, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(a1 + 384) = 1065353216;
+        public float Unknown184;     // offset: 388, sz: 4, origin: 1052501869, parsed: 0.367        // line:   *(_DWORD *)(a1 + 388) = 1052501869;
+        public float Unknown188;     // offset: 392, sz: 4, origin: 1010055512, parsed: 0.011        // line:   *(_DWORD *)(a1 + 392) = 1010055512;
+        public float Unknown18C;     // offset: 396, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(a1 + 396) = 1065353216;
+        public float Unknown190;     // offset: 400, sz: 4, origin: 1061158912i64, parsed: 0.75, comment: unaligned to 8 bytes! two packed floats in a QWORD?(1)
+        public float Unknown194;     // offset: 404, sz: 4, origin: 1061158912i64, parsed: 0, comment: unaligned to 8 bytes! two packed floats in a QWORD?(2)        // line:   *(_QWORD *)(a1 + 400) = 1061158912i64;
+        public float Unknown198;     // offset: 408, sz: 4, origin: 0, parsed: 0        // line:   *(_DWORD *)(a1 + 408) = 0;
+        public float Unknown19C;     // offset: 412, sz: 4, origin: 1056964608, parsed: 0.5        // line:   *(_DWORD *)(a1 + 412) = 1056964608;
+        public float Unknown1A0;     // offset: 416, sz: 4, origin: 1034952901, parsed: 0.086        // line:   *(_DWORD *)(a1 + 416) = 1034952901;
+        public float Unknown1A4;     // offset: 420, sz: 4, origin: 1059984507, parsed: 0.68        // line:   *(_DWORD *)(a1 + 420) = 1059984507;
+        public float Unknown1A8;     // offset: 424, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(a1 + 424) = 1065353216;
+        public float Unknown1AC;     // offset: 428, sz: 4, origin: 1056964608, parsed: 0.5        // line:   *(_DWORD *)(a1 + 428) = 1056964608;
+        public float Unknown1B0;     // offset: 432, sz: 4, origin: 1142292480, parsed: 600        // line:   *(_DWORD *)(a1 + 432) = 1142292480;
+        public float Unknown1B4;     // offset: 436, sz: 4, origin: 1120403456, parsed: 100        // line:   *(_DWORD *)(a1 + 436) = 1120403456;
+        public float Unknown1B8;     // offset: 440, sz: 4, origin: 1060320051, parsed: 0.7        // line:   *(_DWORD *)(a1 + 440) = 1060320051;
+        public float Unknown1BC;     // offset: 444, sz: 4, origin: 1060320051, parsed: 0.7        // line:   *(_DWORD *)(a1 + 444) = 1060320051;
+        public float Unknown1C0;     // offset: 448, sz: 4, origin: 1120403456, parsed: 100        // line:   *(_DWORD *)(a1 + 448) = 1120403456;
+        public float Unknown1C4;     // offset: 452, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(a1 + 452) = 1065353216;
+        public float Unknown1C8;     // offset: 456, sz: 4, origin: 1058642330, parsed: 0.6        // line:   *(_DWORD *)(a1 + 456) = 1058642330;
+        public float Unknown1CC;     // offset: 460, sz: 4, origin: 1063675494, parsed: 0.9        // line:   *(_DWORD *)(a1 + 460) = 1063675494;
+        public float Unknown1D0;     // offset: 464, sz: 4, origin: 1048576000, parsed: 0.25        // line:   *(_DWORD *)(a1 + 464) = 1048576000;
+        [NMS(Size = 0x80)]
+        public string Unknown1D4;     // offset: 468, sz: 128, origin:  Str1        // line:   strncpy((char *)(a1 + 468), Str1, 0x80ui64);
+        // line:   *(_BYTE *)(v1 + 595) = 0;
+        [NMS(Size = 0x80)]
+        public string Unknown254;     // offset: 596, sz: 128, origin:  "TEXTURES/UI/FRONTEND/ICONS/CATEGORIES/UPGRADECAT.DAMAGE.PNG"        // line:   strncpy((char *)(v1 + 596), "TEXTURES/UI/FRONTEND/ICONS/CATEGORIES/UPGRADECAT.DAMAGE.PNG", 0x80ui64);
+        // line:   *(_BYTE *)(v1 + 723) = 0;
+        [NMS(Size = 0x80)]
+        public string Unknown2D4;     // offset: 724, sz: 128, origin:  "TEXTURES/UI/FRONTEND/ICONS/CATEGORIES/UPGRADECAT.MINE.PNG"        // line:   strncpy((char *)(v1 + 724), "TEXTURES/UI/FRONTEND/ICONS/CATEGORIES/UPGRADECAT.MINE.PNG", 0x80ui64);
+        // line:   *(_BYTE *)(v1 + 851) = 0;
+        [NMS(Size = 0x80)]
+        public string Unknown354;     // offset: 852, sz: 128, origin:  "TEXTURES/UI/FRONTEND/ICONS/CATEGORIES/UPGRADECAT.TIME.PNG"        // line:   strncpy((char *)(v1 + 852), "TEXTURES/UI/FRONTEND/ICONS/CATEGORIES/UPGRADECAT.TIME.PNG", 0x80ui64);
+        // line:   *(_BYTE *)(v1 + 979) = 0;
+        [NMS(Size = 0x80)]
+        public string Unknown3D4;     // offset: 980, sz: 128, origin:  "TEXTURES/UI/FRONTEND/ICONS/CATEGORIES/UPGRADECAT.GENERIC.PNG"        // line:   strncpy((char *)(v1 + 980), "TEXTURES/UI/FRONTEND/ICONS/CATEGORIES/UPGRADECAT.GENERIC.PNG", 0x80ui64);
+        // line:   *(_BYTE *)(v1 + 1107) = 0;
+        [NMS(Size = 0x80)]
+        public string Unknown454;     // offset: 1108, sz: 128, origin:  Str1        // line:   strncpy((char *)(v1 + 1108), Str1, 0x80ui64);
+        // line:   *(_BYTE *)(v1 + 1235) = 0;
+        [NMS(Size = 0x80)]
+        public string Unknown4D4;     // offset: 1236, sz: 128, origin:  Str1        // line:   strncpy((char *)(v1 + 1236), Str1, 0x80ui64);
+        // line:   *(_BYTE *)(v1 + 1363) = 0;
+        [NMS(Size = 0x80)]
+        public string Unknown554;     // offset: 1364, sz: 128, origin:  "TEXTURES/UI/FRONTEND/ICONS/CATEGORIES/UPGRADECAT.DAMAGE.PNG"        // line:   strncpy((char *)(v1 + 1364), "TEXTURES/UI/FRONTEND/ICONS/CATEGORIES/UPGRADECAT.DAMAGE.PNG", 0x80ui64);
+        // line:   *(_BYTE *)(v1 + 1491) = 0;
+        [NMS(Size = 0x80)]
+        public string Unknown5D4;     // offset: 1492, sz: 128, origin:  "TEXTURES/UI/FRONTEND/ICONS/CATEGORIES/UPGRADECAT.MINE.PNG"        // line:   strncpy((char *)(v1 + 1492), "TEXTURES/UI/FRONTEND/ICONS/CATEGORIES/UPGRADECAT.MINE.PNG", 0x80ui64);
+        // line:   *(_BYTE *)(v1 + 1619) = 0;
+        [NMS(Size = 0x80)]
+        public string Unknown654;     // offset: 1620, sz: 128, origin:  "TEXTURES/UI/FRONTEND/ICONS/CATEGORIES/UPGRADECAT.RANGE.PNG"        // line:   strncpy((char *)(v1 + 1620), "TEXTURES/UI/FRONTEND/ICONS/CATEGORIES/UPGRADECAT.RANGE.PNG", 0x80ui64);
+        // line:   *(_BYTE *)(v1 + 1747) = 0;
+        [NMS(Size = 0x80)]
+        public string Unknown6D4;     // offset: 1748, sz: 128, origin:  "TEXTURES/UI/FRONTEND/ICONS/CATEGORIES/UPGRADECAT.GENERIC.PNG"        // line:   strncpy((char *)(v1 + 1748), "TEXTURES/UI/FRONTEND/ICONS/CATEGORIES/UPGRADECAT.GENERIC.PNG", 0x80ui64);
+        // line:   *(_BYTE *)(v1 + 1875) = 0;
+        [NMS(Size = 0x80)]
+        public string Unknown754;     // offset: 1876, sz: 128, origin:  "TEXTURES/UI/FRONTEND/ICONS/CATEGORIES/UPGRADECAT.GENERIC.PNG"        // line:   strncpy((char *)(v1 + 1876), "TEXTURES/UI/FRONTEND/ICONS/CATEGORIES/UPGRADECAT.GENERIC.PNG", 0x80ui64);
+        // line:   *(_BYTE *)(v1 + 2003) = 0;
+        [NMS(Size = 0x80)]
+        public string Unknown7D4;     // offset: 2004, sz: 128, origin:  "TEXTURES/UI/FRONTEND/ICONS/CATEGORIES/UPGRADECAT.TIME.PNG"        // line:   strncpy((char *)(v1 + 2004), "TEXTURES/UI/FRONTEND/ICONS/CATEGORIES/UPGRADECAT.TIME.PNG", 0x80ui64);
+        // line:   *(_BYTE *)(v1 + 2131) = 0;
+        [NMS(Size = 0x80)]
+        public string Unknown854;     // offset: 2132, sz: 128, origin:  "TEXTURES/UI/FRONTEND/ICONS/CATEGORIES/UPGRADECAT.GENERIC.PNG"        // line:   strncpy((char *)(v1 + 2132), "TEXTURES/UI/FRONTEND/ICONS/CATEGORIES/UPGRADECAT.GENERIC.PNG", 0x80ui64);
+        // line:   *(_BYTE *)(v1 + 2259) = 0;
+        [NMS(Size = 0x80)]
+        public string Unknown8D4;     // offset: 2260, sz: 128, origin:  "TEXTURES/UI/FRONTEND/ICONS/CATEGORIES/UPGRADECAT.GENERIC.PNG"        // line:   strncpy((char *)(v1 + 2260), "TEXTURES/UI/FRONTEND/ICONS/CATEGORIES/UPGRADECAT.GENERIC.PNG", 0x80ui64);
+        // line:   *(_BYTE *)(v1 + 2387) = 0;
+        [NMS(Size = 0x80)]
+        public string Unknown954;     // offset: 2388, sz: 128, origin:  "TEXTURES/UI/FRONTEND/ICONS/CATEGORIES/UPGRADECAT.GENERIC.PNG"        // line:   strncpy((char *)(v1 + 2388), "TEXTURES/UI/FRONTEND/ICONS/CATEGORIES/UPGRADECAT.GENERIC.PNG", 0x80ui64);
+        // line:   *(_BYTE *)(v1 + 2515) = 0;
+        [NMS(Size = 0x80)]
+        public string Unknown9D4;     // offset: 2516, sz: 128, origin:  "TEXTURES/UI/FRONTEND/ICONS/CATEGORIES/UPGRADECAT.GENERIC.PNG"        // line:   strncpy((char *)(v1 + 2516), "TEXTURES/UI/FRONTEND/ICONS/CATEGORIES/UPGRADECAT.GENERIC.PNG", 0x80ui64);
+        // line:   *(_BYTE *)(v1 + 2643) = 0;
+        [NMS(Size = 0x80)]
+        public string UnknownA54;     // offset: 2644, sz: 128, origin:  "TEXTURES/UI/FRONTEND/ICONS/CATEGORIES/UPGRADECAT.GENERIC.PNG"        // line:   strncpy((char *)(v1 + 2644), "TEXTURES/UI/FRONTEND/ICONS/CATEGORIES/UPGRADECAT.GENERIC.PNG", 0x80ui64);
+        // line:   *(_BYTE *)(v1 + 2771) = 0;
+        [NMS(Size = 0x80)]
+        public string UnknownAD4;     // offset: 2772, sz: 128, origin:  Str1        // line:   strncpy((char *)(v1 + 2772), Str1, 0x80ui64);
+        // line:   *(_BYTE *)(v1 + 2899) = 0;
+        [NMS(Size = 0x80)]
+        public string UnknownB54;     // offset: 2900, sz: 128, origin:  "TEXTURES/UI/FRONTEND/ICONS/CATEGORIES/UPGRADECAT.DAMAGE.PNG"        // line:   strncpy((char *)(v1 + 2900), "TEXTURES/UI/FRONTEND/ICONS/CATEGORIES/UPGRADECAT.DAMAGE.PNG", 0x80ui64);
+        // line:   *(_BYTE *)(v1 + 3027) = 0;
+        [NMS(Size = 0x80)]
+        public string UnknownBD4;     // offset: 3028, sz: 128, origin:  "TEXTURES/UI/FRONTEND/ICONS/CATEGORIES/UPGRADECAT.DAMAGE.PNG"        // line:   strncpy((char *)(v1 + 3028), "TEXTURES/UI/FRONTEND/ICONS/CATEGORIES/UPGRADECAT.DAMAGE.PNG", 0x80ui64);
+        // line:   *(_BYTE *)(v1 + 3155) = 0;
+        [NMS(Size = 0x80)]
+        public string UnknownC54;     // offset: 3156, sz: 128, origin:  "TEXTURES/UI/FRONTEND/ICONS/CATEGORIES/UPGRADECAT.RANGE.PNG"        // line:   strncpy((char *)(v1 + 3156), "TEXTURES/UI/FRONTEND/ICONS/CATEGORIES/UPGRADECAT.RANGE.PNG", 0x80ui64);
+        // line:   *(_BYTE *)(v1 + 3283) = 0;
+        [NMS(Size = 0x80)]
+        public string UnknownCD4;     // offset: 3284, sz: 128, origin:  "TEXTURES/UI/FRONTEND/ICONS/CATEGORIES/UPGRADECAT.GENERIC.PNG"        // line:   strncpy((char *)(v1 + 3284), "TEXTURES/UI/FRONTEND/ICONS/CATEGORIES/UPGRADECAT.GENERIC.PNG", 0x80ui64);
+        // line:   *(_BYTE *)(v1 + 3411) = 0;
+        [NMS(Size = 0x80)]
+        public string UnknownD54;     // offset: 3412, sz: 128, origin:  "TEXTURES/UI/FRONTEND/ICONS/CATEGORIES/UPGRADECAT.GENERIC.PNG"        // line:   strncpy((char *)(v1 + 3412), "TEXTURES/UI/FRONTEND/ICONS/CATEGORIES/UPGRADECAT.GENERIC.PNG", 0x80ui64);
+        // line:   *(_BYTE *)(v1 + 3539) = 0;
+        [NMS(Size = 0x80)]
+        public string UnknownDD4;     // offset: 3540, sz: 128, origin:  "TEXTURES/UI/FRONTEND/ICONS/CATEGORIES/BUILDCATAGORY.ALLOY.PNG"        // line:   strncpy((char *)(v1 + 3540), "TEXTURES/UI/FRONTEND/ICONS/CATEGORIES/BUILDCATAGORY.ALLOY.PNG", 0x80ui64);
+        // line:   *(_BYTE *)(v1 + 3667) = 0;
+        [NMS(Size = 0x80)]
+        public string UnknownE54;     // offset: 3668, sz: 128, origin:  "TEXTURES/UI/FRONTEND/ICONS/CATEGORIES/UPGRADECAT.MINE.PNG"        // line:   strncpy((char *)(v1 + 3668), "TEXTURES/UI/FRONTEND/ICONS/CATEGORIES/UPGRADECAT.MINE.PNG", 0x80ui64);
+        // line:   *(_BYTE *)(v1 + 3795) = 0;
+        [NMS(Size = 0x80)]
+        public string UnknownED4;     // offset: 3796, sz: 128, origin:  Str1        // line:   strncpy((char *)(v1 + 3796), Str1, 0x80ui64);
+        // line:   *(_BYTE *)(v1 + 3923) = 0;
+        [NMS(Size = 0x80)]
+        public string UnknownF54;     // offset: 3924, sz: 128, origin:  Str1        // line:   strncpy((char *)(v1 + 3924), Str1, 0x80ui64);
+        // line:   *(_BYTE *)(v1 + 4051) = 0;
+        [NMS(Size = 0x80)]
+        public string UnknownFD4;     // offset: 4052, sz: 128, origin:  Str1        // line:   strncpy((char *)(v1 + 4052), Str1, 0x80ui64);
+        // line:   *(_BYTE *)(v1 + 4179) = 0;
+        [NMS(Size = 0x80)]
+        public string Unknown1054;     // offset: 4180, sz: 128, origin:  Str1        // line:   strncpy((char *)(v1 + 4180), Str1, 0x80ui64);
+        // line:   *(_BYTE *)(v1 + 4307) = 0;
+        [NMS(Size = 0x80)]
+        public string Unknown10D4;     // offset: 4308, sz: 128, origin:  Str1        // line:   strncpy((char *)(v1 + 4308), Str1, 0x80ui64);
+        // line:   *(_BYTE *)(v1 + 4435) = 0;
+        [NMS(Size = 0x80)]
+        public string Unknown1154;     // offset: 4436, sz: 128, origin:  Str1        // line:   strncpy((char *)(v1 + 4436), Str1, 0x80ui64);
+        // line:   *(_BYTE *)(v1 + 4563) = 0;
+        [NMS(Size = 0x80)]
+        public string Unknown11D4;     // offset: 4564, sz: 128, origin:  Str1        // line:   strncpy((char *)(v1 + 4564), Str1, 0x80ui64);
+        // line:   *(_BYTE *)(v1 + 4691) = 0;
+        [NMS(Size = 0x80)]
+        public string Unknown1254;     // offset: 4692, sz: 128, origin:  Str1        // line:   strncpy((char *)(v1 + 4692), Str1, 0x80ui64);
+        // line:   *(_BYTE *)(v1 + 4819) = 0;
+        [NMS(Size = 0x80)]
+        public string Unknown12D4;     // offset: 4820, sz: 128, origin:  Str1        // line:   strncpy((char *)(v1 + 4820), Str1, 0x80ui64);
+        // line:   *(_BYTE *)(v1 + 4947) = 0;
+        [NMS(Size = 0x80)]
+        public string Unknown1354;     // offset: 4948, sz: 128, origin:  Str1        // line:   strncpy((char *)(v1 + 4948), Str1, 0x80ui64);
+        // line:   *(_BYTE *)(v1 + 5075) = 0;
+        [NMS(Size = 0x80)]
+        public string Unknown13D4;     // offset: 5076, sz: 128, origin:  Str1        // line:   strncpy((char *)(v1 + 5076), Str1, 0x80ui64);
+        // line:   *(_BYTE *)(v1 + 5203) = 0;
+        [NMS(Size = 0x80)]
+        public string Unknown1454;     // offset: 5204, sz: 128, origin:  Str1        // line:   strncpy((char *)(v1 + 5204), Str1, 0x80ui64);
+        // line:   *(_BYTE *)(v1 + 5331) = 0;
+        [NMS(Size = 0x80)]
+        public string Unknown14D4;     // offset: 5332, sz: 128, origin:  Str1        // line:   strncpy((char *)(v1 + 5332), Str1, 0x80ui64);
+        // line:   *(_BYTE *)(v1 + 5459) = 0;
+        [NMS(Size = 0x80)]
+        public string Unknown1554;     // offset: 5460, sz: 128, origin:  Str1        // line:   strncpy((char *)(v1 + 5460), Str1, 0x80ui64);
+        // line:   *(_BYTE *)(v1 + 5587) = 0;
+        [NMS(Size = 0x80)]
+        public string Unknown15D4;     // offset: 5588, sz: 128, origin:  Str1        // line:   strncpy((char *)(v1 + 5588), Str1, 0x80ui64);
+        // line:   *(_BYTE *)(v1 + 5715) = 0;
+        [NMS(Size = 0x80)]
+        public string Unknown1654;     // offset: 5716, sz: 128, origin:  Str1        // line:   strncpy((char *)(v1 + 5716), Str1, 0x80ui64);
+        // line:   *(_BYTE *)(v1 + 5843) = 0;
+        [NMS(Size = 0x80)]
+        public string Unknown16D4;     // offset: 5844, sz: 128, origin:  Str1        // line:   strncpy((char *)(v1 + 5844), Str1, 0x80ui64);
+        // line:   *(_BYTE *)(v1 + 5971) = 0;
+        [NMS(Size = 0x80)]
+        public string Unknown1754;     // offset: 5972, sz: 128, origin:  Str1        // line:   strncpy((char *)(v1 + 5972), Str1, 0x80ui64);
+        // line:   *(_BYTE *)(v1 + 6099) = 0;
+        [NMS(Size = 0x80)]
+        public string Unknown17D4;     // offset: 6100, sz: 128, origin:  Str1        // line:   strncpy((char *)(v1 + 6100), Str1, 0x80ui64);
+        // line:   *(_BYTE *)(v1 + 6227) = 0;
+        [NMS(Size = 0x80)]
+        public string Unknown1854;     // offset: 6228, sz: 128, origin:  Str1        // line:   strncpy((char *)(v1 + 6228), Str1, 0x80ui64);
+        // line:   *(_BYTE *)(v1 + 6355) = 0;
+        [NMS(Size = 0x80)]
+        public string Unknown18D4;     // offset: 6356, sz: 128, origin:  Str1        // line:   strncpy((char *)(v1 + 6356), Str1, 0x80ui64);
+        // line:   *(_BYTE *)(v1 + 6483) = 0;
+        [NMS(Size = 0x80)]
+        public string Unknown1954;     // offset: 6484, sz: 128, origin:  Str1        // line:   strncpy((char *)(v1 + 6484), Str1, 0x80ui64);
+        // line:   *(_BYTE *)(v1 + 6611) = 0;
+        [NMS(Size = 0x80)]
+        public string Unknown19D4;     // offset: 6612, sz: 128, origin:  Str1        // line:   strncpy((char *)(v1 + 6612), Str1, 0x80ui64);
+        // line:   *(_BYTE *)(v1 + 6739) = 0;
+        [NMS(Size = 0x80)]
+        public string Unknown1A54;     // offset: 6740, sz: 128, origin:  Str1        // line:   strncpy((char *)(v1 + 6740), Str1, 0x80ui64);
+        // line:   *(_BYTE *)(v1 + 6867) = 0;
+        [NMS(Size = 0x80)]
+        public string Unknown1AD4;     // offset: 6868, sz: 128, origin:  Str1        // line:   strncpy((char *)(v1 + 6868), Str1, 0x80ui64);
+        // line:   *(_BYTE *)(v1 + 6995) = 0;
+        [NMS(Size = 0x80)]
+        public string Unknown1B54;     // offset: 6996, sz: 128, origin:  Str1        // line:   strncpy((char *)(v1 + 6996), Str1, 0x80ui64);
+        // line:   *(_BYTE *)(v1 + 7123) = 0;
+        [NMS(Size = 0x80)]
+        public string Unknown1BD4;     // offset: 7124, sz: 128, origin:  Str1        // line:   strncpy((char *)(v1 + 7124), Str1, 0x80ui64);
+        // line:   *(_BYTE *)(v1 + 7251) = 0;
+        [NMS(Size = 0x80)]
+        public string Unknown1C54;     // offset: 7252, sz: 128, origin:  Str1        // line:   strncpy((char *)(v1 + 7252), Str1, 0x80ui64);
+        // line:   *(_BYTE *)(v1 + 7379) = 0;
+        [NMS(Size = 0x80)]
+        public string Unknown1CD4;     // offset: 7380, sz: 128, origin:  Str1        // line:   strncpy((char *)(v1 + 7380), Str1, 0x80ui64);
+        // line:   *(_BYTE *)(v1 + 7507) = 0;
+        public float Unknown1D54;     // offset: 7508, sz: 4, origin: 1094713344, parsed: 12        // line:   *(_DWORD *)(v1 + 7508) = 1094713344;
+        public int Unknown1D58;     // offset: 7512, sz: 4, origin: 1500, parsed: 1500        // line:   *(_DWORD *)(v1 + 7512) = 1500;
+        public float Unknown1D5C;     // offset: 7516, sz: 4, origin: 1176256512, parsed: 10000        // line:   *(_DWORD *)(v1 + 7516) = 1176256512;
+        public float Unknown1D60;     // offset: 7520, sz: 4, origin: 1077936128, parsed: 3        // line:   *(_DWORD *)(v1 + 7520) = 1077936128;
+        public float Unknown1D64;     // offset: 7524, sz: 4, origin: 1077936128, parsed: 3        // line:   *(_DWORD *)(v1 + 7524) = 1077936128;
+        public float Unknown1D68;     // offset: 7528, sz: 4, origin: 1155596288, parsed: 1800        // line:   *(_DWORD *)(v1 + 7528) = 1155596288;
+        public float Unknown1D6C;     // offset: 7532, sz: 4, origin: 1106247680, parsed: 30        // line:   *(_DWORD *)(v1 + 7532) = 1106247680;
+        public float Unknown1D70;     // offset: 7536, sz: 4, origin: 1080033280, parsed: 3.5        // line:   *(_DWORD *)(v1 + 7536) = 1080033280;
+        public float Unknown1D74;     // offset: 7540, sz: 4, origin: 1098383360, parsed: 15.5        // line:   *(_DWORD *)(v1 + 7540) = 1098383360;
+        public float Unknown1D78;     // offset: 7544, sz: 4, origin: 1082130432, parsed: 4        // line:   *(_DWORD *)(v1 + 7544) = 1082130432;
+        public float Unknown1D7C;     // offset: 7548, sz: 4, origin: 1090519040, parsed: 8        // line:   *(_DWORD *)(v1 + 7548) = 1090519040;
+        public float Unknown1D80;     // offset: 7552, sz: 4, origin: 1142292480, parsed: 600        // line:   *(_DWORD *)(v1 + 7552) = 1142292480;
+        public float Unknown1D84;     // offset: 7556, sz: 4, origin: 1082130432, parsed: 4        // line:   *(_DWORD *)(v1 + 7556) = 1082130432;
+        public float Unknown1D88;     // offset: 7560, sz: 4, origin: 1101004800, parsed: 20        // line:   *(_DWORD *)(v1 + 7560) = 1101004800;
+        public float Unknown1D8C;     // offset: 7564, sz: 4, origin: 0x40000000, parsed: 2        // line:   *(_DWORD *)(v1 + 7564) = 0x40000000;
+        public float Unknown1D90;     // offset: 7568, sz: 4, origin: 1106247680, parsed: 30        // line:   *(_DWORD *)(v1 + 7568) = 1106247680;
+        public float Unknown1D94;     // offset: 7572, sz: 4, origin: 1084227584, parsed: 5        // line:   *(_DWORD *)(v1 + 7572) = 1084227584;
+        public float Unknown1D98;     // offset: 7576, sz: 4, origin: 1106247680, parsed: 30        // line:   *(_DWORD *)(v1 + 7576) = 1106247680;
+        public float Unknown1D9C;     // offset: 7580, sz: 4, origin: 1106247680, parsed: 30        // line:   *(_DWORD *)(v1 + 7580) = 1106247680;
+        public float Unknown1DA0;     // offset: 7584, sz: 4, origin: 1102053376, parsed: 22        // line:   *(_DWORD *)(v1 + 7584) = 1102053376;
+        public float Unknown1DA4;     // offset: 7588, sz: 4, origin: 1084227584, parsed: 5        // line:   *(_DWORD *)(v1 + 7588) = 1084227584;
+        public float Unknown1DA8;     // offset: 7592, sz: 4, origin: 1150681088, parsed: 1200        // line:   *(_DWORD *)(v1 + 7592) = 1150681088;
+        public float Unknown1DAC;     // offset: 7596, sz: 4, origin: 1133903872, parsed: 300        // line:   *(_DWORD *)(v1 + 7596) = 1133903872;
+        public float Unknown1DB0;     // offset: 7600, sz: 4, origin: 1112014848, parsed: 50        // line:   *(_DWORD *)(v1 + 7600) = 1112014848;
+        public float Unknown1DB4;     // offset: 7604, sz: 4, origin: 1159069696, parsed: 2400        // line:   *(_DWORD *)(v1 + 7604) = 1159069696;
+        public float Unknown1DB8;     // offset: 7608, sz: 4, origin: 1159069696, parsed: 2400        // line:   *(_DWORD *)(v1 + 7608) = 1159069696;
+        public float Unknown1DBC;     // offset: 7612, sz: 4, origin: 1150681088, parsed: 1200        // line:   *(_DWORD *)(v1 + 7612) = 1150681088;
+        public float Unknown1DC0;     // offset: 7616, sz: 4, origin: 1150681088, parsed: 1200        // line:   *(_DWORD *)(v1 + 7616) = 1150681088;
+        public float Unknown1DC4;     // offset: 7620, sz: 4, origin: 1142292480, parsed: 600        // line:   *(_DWORD *)(v1 + 7620) = 1142292480;
+        public float Unknown1DC8;     // offset: 7624, sz: 4, origin: 1099956224, parsed: 18        // line:   *(_DWORD *)(v1 + 7624) = 1099956224;
+        public float Unknown1DCC;     // offset: 7628, sz: 4, origin: 1101004800, parsed: 20        // line:   *(_DWORD *)(v1 + 7628) = 1101004800;
+        public float Unknown1DD0;     // offset: 7632, sz: 4, origin: 1110704128, parsed: 45        // line:   *(_DWORD *)(v1 + 7632) = 1110704128;
+        public float Unknown1DD4;     // offset: 7636, sz: 4, origin: 1090519040, parsed: 8        // line:   *(_DWORD *)(v1 + 7636) = 1090519040;
+        public float Unknown1DD8;     // offset: 7640, sz: 4, origin: 1082130432, parsed: 4        // line:   *(_DWORD *)(v1 + 7640) = 1082130432;
+        public float Unknown1DDC;     // offset: 7644, sz: 4, origin: 1090519040, parsed: 8        // line:   *(_DWORD *)(v1 + 7644) = 1090519040;
+        public float Unknown1DE0;     // offset: 7648, sz: 4, origin: 1069547520, parsed: 1.5        // line:   *(_DWORD *)(v1 + 7648) = 1069547520;
+        public float Unknown1DE4;     // offset: 7652, sz: 4, origin: 1077936128, parsed: 3        // line:   *(_DWORD *)(v1 + 7652) = 1077936128;
+        public float Unknown1DE8;     // offset: 7656, sz: 4, origin: 1084227584, parsed: 5        // line:   *(_DWORD *)(v1 + 7656) = 1084227584;
+
+        // missing 4 bytes at offset 7656
+        // could be padding, a undefined subroutine or a pointer accessing larger memory
+        [NMS(Size = 0x4, Ignore = true)]
+        public byte[] Padding1DEC;        // offset: 7660, sz: 4, comment: auto padding 
+
+        public float Unknown1DF0;     // offset: 7664, sz: 4, origin: 1062836634, parsed: 0.85        // line:   *(_DWORD *)(v1 + 7664) = 1062836634;
+        public float Unknown1DF4;     // offset: 7668, sz: 4, origin: 1042334876, parsed: 0.157        // line:   *(_DWORD *)(v1 + 7668) = 1042334876;
+        public float Unknown1DF8;     // offset: 7672, sz: 4, origin: 1042334876, parsed: 0.157        // line:   *(_DWORD *)(v1 + 7672) = 1042334876;
+        public float Unknown1DFC;     // offset: 7676, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(v1 + 7676) = 1065353216;
+        public float Unknown1E00;     // offset: 7680, sz: 4, origin: 1062836634, parsed: 0.85        // line:   *(_DWORD *)(v1 + 7680) = 1062836634;
+        public float Unknown1E04;     // offset: 7684, sz: 4, origin: 1042334876, parsed: 0.157        // line:   *(_DWORD *)(v1 + 7684) = 1042334876;
+        public float Unknown1E08;     // offset: 7688, sz: 4, origin: 1042334876, parsed: 0.157        // line:   *(_DWORD *)(v1 + 7688) = 1042334876;
+        public float Unknown1E0C;     // offset: 7692, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(v1 + 7692) = 1065353216;
+        [NMS(Size = 0x20)]
+        public string Unknown1E10;     // offset: 7696, sz: 32, origin:  "ks"        // line:   strncpy((char *)(v1 + 7696), "ks", 0x20ui64);
+        // line:   *(_BYTE *)(v1 + 7727) = 0;
+        public float Unknown1E30;     // offset: 7728, sz: 4, origin: 1128792064, parsed: 200        // line:   *(_DWORD *)(v1 + 7728) = 1128792064;
+        public float Unknown1E34;     // offset: 7732, sz: 4, origin: 1109393408, parsed: 40        // line:   *(_DWORD *)(v1 + 7732) = 1109393408;
+        public float Unknown1E38;     // offset: 7736, sz: 4, origin: 1045220557, parsed: 0.2        // line:   *(_DWORD *)(v1 + 7736) = 1045220557;
+        public float Unknown1E3C;     // offset: 7740, sz: 4, origin: 1128792064, parsed: 200        // line:   *(_DWORD *)(v1 + 7740) = 1128792064;
+        public float Unknown1E40;     // offset: 7744, sz: 4, origin: -1026424832, parsed: -105        // line:   *(_DWORD *)(v1 + 7744) = -1026424832;
+        public float Unknown1E44;     // offset: 7748, sz: 4, origin: 1131413504, parsed: 240        // line:   *(_DWORD *)(v1 + 7748) = 1131413504;
+        public float Unknown1E48;     // offset: 7752, sz: 4, origin: -1054867456, parsed: -10        // line:   *(_DWORD *)(v1 + 7752) = -1054867456;
+        public float Unknown1E4C;     // offset: 7756, sz: 4, origin: 1127481344, parsed: 180        // line:   *(_DWORD *)(v1 + 7756) = 1127481344;
+        public float Unknown1E50;     // offset: 7760, sz: 4, origin: -1029701632, parsed: -80        // line:   *(_DWORD *)(v1 + 7760) = -1029701632;
+        public float Unknown1E54;     // offset: 7764, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(v1 + 7764) = 1065353216;
+        public float Unknown1E58;     // offset: 7768, sz: 4, origin: 1092616192, parsed: 10        // line:   *(_DWORD *)(v1 + 7768) = 1092616192;
+        public float Unknown1E5C;     // offset: 7772, sz: 4, origin: 1056964608, parsed: 0.5        // line:   *(_DWORD *)(v1 + 7772) = 1056964608;
+        public float Unknown1E60;     // offset: 7776, sz: 4, origin: 1056964608, parsed: 0.5        // line:   *(_DWORD *)(v1 + 7776) = 1056964608;
+        public float Unknown1E64;     // offset: 7780, sz: 4, origin: 1036831949, parsed: 0.1        // line:   *(_DWORD *)(v1 + 7780) = 1036831949;
+        public float Unknown1E68;     // offset: 7784, sz: 4, origin: 1112014848, parsed: 50        // line:   *(_DWORD *)(v1 + 7784) = 1112014848;
+        public float Unknown1E6C;     // offset: 7788, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(v1 + 7788) = 1065353216;
+        public float Unknown1E70;     // offset: 7792, sz: 4, origin: 1128792064, parsed: 200        // line:   *(_DWORD *)(v1 + 7792) = 1128792064;
+        public float Unknown1E74;     // offset: 7796, sz: 4, origin: 1036831949, parsed: 0.1        // line:   *(_DWORD *)(v1 + 7796) = 1036831949;
+        public float Unknown1E78;     // offset: 7800, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(v1 + 7800) = 1065353216;
+        public float Unknown1E7C;     // offset: 7804, sz: 4, origin: 1112014848, parsed: 50        // line:   *(_DWORD *)(v1 + 7804) = 1112014848;
+        public float Unknown1E80;     // offset: 7808, sz: 4, origin: 0x40000000i64, parsed: 2, comment: unaligned to 8 bytes! two packed floats in a QWORD?(1)
+        public float Unknown1E84;     // offset: 7812, sz: 4, origin: 0x40000000i64, parsed: 0, comment: unaligned to 8 bytes! two packed floats in a QWORD?(2)        // line:   *(_QWORD *)(v1 + 7808) = 0x40000000i64;
+        public float Unknown1E88;     // offset: 7816, sz: 4, origin: 0, parsed: 0        // line:   *(_DWORD *)(v1 + 7816) = 0;
+
+        // missing 4 bytes at offset 7816
+        // could be padding, a undefined subroutine or a pointer accessing larger memory
+        [NMS(Size = 0x4, Ignore = true)]
+        public byte[] Padding1E8C;        // offset: 7820, sz: 4, comment: auto padding 
+
+        public float Unknown1E90;     // offset: 7824, sz: 4, origin: 1059363750, parsed: 0.643        // line:   *(_DWORD *)(v1 + 7824) = 1059363750;
+        public float Unknown1E94;     // offset: 7828, sz: 4, origin: 1044885012, parsed: 0.195        // line:   *(_DWORD *)(v1 + 7828) = 1044885012;
+        public float Unknown1E98;     // offset: 7832, sz: 4, origin: 1040925590, parsed: 0.136        // line:   *(_DWORD *)(v1 + 7832) = 1040925590;
+        public float Unknown1E9C;     // offset: 7836, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(v1 + 7836) = 1065353216;
+        public float Unknown1EA0;     // offset: 7840, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(v1 + 7840) = 1065353216;
+        public float Unknown1EA4;     // offset: 7844, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(v1 + 7844) = 1065353216;
+        public float Unknown1EA8;     // offset: 7848, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(v1 + 7848) = 1065353216;
+        public float Unknown1EAC;     // offset: 7852, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(v1 + 7852) = 1065353216;
+        public float Unknown1EB0;     // offset: 7856, sz: 4, origin: 1032402764, parsed: 0.067        // line:   *(_DWORD *)(v1 + 7856) = 1032402764;
+        public float Unknown1EB4;     // offset: 7860, sz: 4, origin: 1032402764, parsed: 0.067        // line:   *(_DWORD *)(v1 + 7860) = 1032402764;
+        public float Unknown1EB8;     // offset: 7864, sz: 4, origin: 1032402764, parsed: 0.067        // line:   *(_DWORD *)(v1 + 7864) = 1032402764;
+        public float Unknown1EBC;     // offset: 7868, sz: 4, origin: 1063121846, parsed: 0.867        // line:   *(_DWORD *)(v1 + 7868) = 1063121846;
+        public float Unknown1EC0;     // offset: 7872, sz: 4, origin: 1060487823, parsed: 0.71        // line:   *(_DWORD *)(v1 + 7872) = 1060487823;
+        public float Unknown1EC4;     // offset: 7876, sz: 4, origin: 1051159691i64, parsed: 0.327, comment: unaligned to 8 bytes! two packed floats in a QWORD?(1)
+        public float Unknown1EC8;     // offset: 7880, sz: 4, origin: 1051159691i64, parsed: 0, comment: unaligned to 8 bytes! two packed floats in a QWORD?(2)        // line:   *(_QWORD *)(v1 + 7876) = 1051159691i64;
+        public float Unknown1ECC;     // offset: 7884, sz: 4, origin: 1063121846, parsed: 0.867        // line:   *(_DWORD *)(v1 + 7884) = 1063121846;
+        public float Unknown1ED0;     // offset: 7888, sz: 4, origin: 1059598631i64, parsed: 0.657, comment: unaligned to 8 bytes! two packed floats in a QWORD?(1)
+        public float Unknown1ED4;     // offset: 7892, sz: 4, origin: 1059598631i64, parsed: 0, comment: unaligned to 8 bytes! two packed floats in a QWORD?(2)        // line:   *(_QWORD *)(v1 + 7888) = 1059598631i64;
+        public float Unknown1ED8;     // offset: 7896, sz: 4, origin: 0, parsed: 0        // line:   *(_DWORD *)(v1 + 7896) = 0;
+        public float Unknown1EDC;     // offset: 7900, sz: 4, origin: 1063121846, parsed: 0.867        // line:   *(_DWORD *)(v1 + 7900) = 1063121846;
+        public float Unknown1EE0;     // offset: 7904, sz: 4, origin: 1056964608, parsed: 0.5        // line:   *(_DWORD *)(v1 + 7904) = 1056964608;
+
+        // missing 12 bytes at offset 7904
+        // could be padding, a undefined subroutine or a pointer accessing larger memory
+        [NMS(Size = 0xC, Ignore = true)]
+        public byte[] Padding1EE4;        // offset: 7908, sz: 12, comment: auto padding 
+
+        public float Unknown1EF0;     // offset: 7920, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(v1 + 7920) = 1065353216;
+        public float Unknown1EF4;     // offset: 7924, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(v1 + 7924) = 1065353216;
+        public float Unknown1EF8;     // offset: 7928, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(v1 + 7928) = 1065353216;
+        public float Unknown1EFC;     // offset: 7932, sz: 4, origin: 1065353216i64, parsed: 1, comment: unaligned to 8 bytes! two packed floats in a QWORD?(1)
+        public float Unknown1F00;     // offset: 7936, sz: 4, origin: 1065353216i64, parsed: 0, comment: unaligned to 8 bytes! two packed floats in a QWORD?(2)        // line:   *(_QWORD *)(v1 + 7932) = 1065353216i64;
+        public float Unknown1F04;     // offset: 7940, sz: 4, origin: 0i64, parsed: 0, comment: unaligned to 8 bytes! two packed floats in a QWORD?(1)
+        public float Unknown1F08;     // offset: 7944, sz: 4, origin: 0i64, parsed: 0, comment: unaligned to 8 bytes! two packed floats in a QWORD?(2)        // line:   *(_QWORD *)(v1 + 7940) = 0i64;
+        public float Unknown1F0C;     // offset: 7948, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(v1 + 7948) = 1065353216;
+        public float Unknown1F10;     // offset: 7952, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(v1 + 7952) = 1065353216;
+        public float Unknown1F14;     // offset: 7956, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(v1 + 7956) = 1065353216;
+        public float Unknown1F18;     // offset: 7960, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(v1 + 7960) = 1065353216;
+        public float Unknown1F1C;     // offset: 7964, sz: 4, origin: 1065353216i64, parsed: 1, comment: unaligned to 8 bytes! two packed floats in a QWORD?(1)
+        public float Unknown1F20;     // offset: 7968, sz: 4, origin: 1065353216i64, parsed: 0, comment: unaligned to 8 bytes! two packed floats in a QWORD?(2)        // line:   *(_QWORD *)(v1 + 7964) = 1065353216i64;
+        public float Unknown1F24;     // offset: 7972, sz: 4, origin: 0i64, parsed: 0, comment: unaligned to 8 bytes! two packed floats in a QWORD?(1)
+        public float Unknown1F28;     // offset: 7976, sz: 4, origin: 0i64, parsed: 0, comment: unaligned to 8 bytes! two packed floats in a QWORD?(2)        // line:   *(_QWORD *)(v1 + 7972) = 0i64;
+        public float Unknown1F2C;     // offset: 7980, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(v1 + 7980) = 1065353216;
+        public float Unknown1F30;     // offset: 7984, sz: 4, origin: 0x40000000, parsed: 2        // line:   *(_DWORD *)(v1 + 7984) = 0x40000000;
+        public float Unknown1F34;     // offset: 7988, sz: 4, origin: 0x40000000, parsed: 2        // line:   *(_DWORD *)(v1 + 7988) = 0x40000000;
+        public float Unknown1F38;     // offset: 7992, sz: 4, origin: 1067030938, parsed: 1.2        // line:   *(_DWORD *)(v1 + 7992) = 1067030938;
+        public float Unknown1F3C;     // offset: 7996, sz: 4, origin: 0x40000000, parsed: 2        // line:   *(_DWORD *)(v1 + 7996) = 0x40000000;
+        public float Unknown1F40;     // offset: 8000, sz: 4, origin: 0x40000000i64, parsed: 2, comment: unaligned to 8 bytes! two packed floats in a QWORD?(1)
+        public float Unknown1F44;     // offset: 8004, sz: 4, origin: 0x40000000i64, parsed: 0, comment: unaligned to 8 bytes! two packed floats in a QWORD?(2)        // line:   *(_QWORD *)(v1 + 8000) = 0x40000000i64;
+        public float Unknown1F48;     // offset: 8008, sz: 4, origin: 1120403456, parsed: 100        // line:   *(_DWORD *)(v1 + 8008) = 1120403456;
+        public float Unknown1F4C;     // offset: 8012, sz: 4, origin: 1133903872, parsed: 300        // line:   *(_DWORD *)(v1 + 8012) = 1133903872;
+        public float Unknown1F50;     // offset: 8016, sz: 4, origin: 1045220557i64, parsed: 0.2, comment: unaligned to 8 bytes! two packed floats in a QWORD?(1)
+        public float Unknown1F54;     // offset: 8020, sz: 4, origin: 1045220557i64, parsed: 0, comment: unaligned to 8 bytes! two packed floats in a QWORD?(2)        // line:   *(_QWORD *)(v1 + 8016) = 1045220557i64;
+        public float Unknown1F58;     // offset: 8024, sz: 4, origin: 1126170624, parsed: 160        // line:   *(_DWORD *)(v1 + 8024) = 1126170624;
+        public float Unknown1F5C;     // offset: 8028, sz: 4, origin: 1101004800, parsed: 20        // line:   *(_DWORD *)(v1 + 8028) = 1101004800;
+        public float Unknown1F60;     // offset: 8032, sz: 4, origin: 1082130432, parsed: 4        // line:   *(_DWORD *)(v1 + 8032) = 1082130432;
+        public float Unknown1F64;     // offset: 8036, sz: 4, origin: 1061997773, parsed: 0.8        // line:   *(_DWORD *)(v1 + 8036) = 1061997773;
+        public float Unknown1F68;     // offset: 8040, sz: 4, origin: 1092616192, parsed: 10        // line:   *(_DWORD *)(v1 + 8040) = 1092616192;
+        public float Unknown1F6C;     // offset: 8044, sz: 4, origin: 1028443341, parsed: 0.05        // line:   *(_DWORD *)(v1 + 8044) = 1028443341;
+        public float Unknown1F70;     // offset: 8048, sz: 4, origin: 1114636288, parsed: 60        // line:   *(_DWORD *)(v1 + 8048) = 1114636288;
+        public float Unknown1F74;     // offset: 8052, sz: 4, origin: 1112014848, parsed: 50        // line:   *(_DWORD *)(v1 + 8052) = 1112014848;
+        public float Unknown1F78;     // offset: 8056, sz: 4, origin: 1137180672, parsed: 400        // line:   *(_DWORD *)(v1 + 8056) = 1137180672;
+        public float Unknown1F7C;     // offset: 8060, sz: 4, origin: 1053609165, parsed: 0.4        // line:   *(_DWORD *)(v1 + 8060) = 1053609165;
+        public float Unknown1F80;     // offset: 8064, sz: 4, origin: 1041865114, parsed: 0.15        // line:   *(_DWORD *)(v1 + 8064) = 1041865114;
+        public float Unknown1F84;     // offset: 8068, sz: 4, origin: 1109393408, parsed: 40        // line:   *(_DWORD *)(v1 + 8068) = 1109393408;
+        public float Unknown1F88;     // offset: 8072, sz: 4, origin: 1109393408, parsed: 40        // line:   *(_DWORD *)(v1 + 8072) = 1109393408;
+        public float Unknown1F8C;     // offset: 8076, sz: 4, origin: 1067869798, parsed: 1.3        // line:   *(_DWORD *)(v1 + 8076) = 1067869798;
+        public float Unknown1F90;     // offset: 8080, sz: 4, origin: -1073741824, parsed: -2        // line:   *(_DWORD *)(v1 + 8080) = -1073741824;
+        public float Unknown1F94;     // offset: 8084, sz: 4, origin: 0, parsed: 0        // line:   *(_DWORD *)(v1 + 8084) = 0;
+        public float Unknown1F98;     // offset: 8088, sz: 4, origin: 1082130432, parsed: 4        // line:   *(_DWORD *)(v1 + 8088) = 1082130432;
+        public float Unknown1F9C;     // offset: 8092, sz: 4, origin: 1056964608, parsed: 0.5        // line:   *(_DWORD *)(v1 + 8092) = 1056964608;
+        public short Unknown1FA0;     // offset: 8096, sz: 2, origin: 257, parsed: 257        // line:   *(_WORD *)(v1 + 8096) = 257;
+        public bool Unknown1FA2;     // offset: 8098, sz: 1, origin: 1, parsed: 1        // line:   *(_BYTE *)(v1 + 8098) = 1;
+        [NMS(Size = 0x20)]
+        public string Unknown1FA3;     // offset: 8099, sz: 32, origin:  "6:11"        // line:   strncpy((char *)(v1 + 8099), "6:11", 0x20ui64);
+        // line:   *(_BYTE *)(v1 + 8130) = 0;
+        [NMS(Size = 0x20)]
+        public string Unknown1FC3;     // offset: 8131, sz: 32, origin:  "19:07"        // line:   strncpy((char *)(v1 + 8131), "19:07", 0x20ui64);
+        // line:   // the parser should now add 1 byte of padding after the string
+        // line:   *(_BYTE *)(v1 + 8162) = 0;
+
+        // missing 1 bytes at offset 8131
+        // does 8131 contain a string which doesn't use all available space?
+        [NMS(Size = 0x1, Ignore = true)]
+        public byte[] Padding1FE3;        // offset: 8163, sz: 1, comment: auto padding 
+
+        public float Unknown1FE4;     // offset: 8164, sz: 4, origin: 1069547520, parsed: 1.5        // line:   *(_DWORD *)(v1 + 8164) = 1069547520;
+        public float Unknown1FE8;     // offset: 8168, sz: 4, origin: 1058642330, parsed: 0.6        // line:   *(_DWORD *)(v1 + 8168) = 1058642330;
+        public float Unknown1FEC;     // offset: 8172, sz: 4, origin: 1045220557, parsed: 0.2        // line:   *(_DWORD *)(v1 + 8172) = 1045220557;
+        public float Unknown1FF0;     // offset: 8176, sz: 4, origin: 1036831949, parsed: 0.1        // line:   *(_DWORD *)(v1 + 8176) = 1036831949;
+        public float Unknown1FF4;     // offset: 8180, sz: 4, origin: 1092616192, parsed: 10        // line:   *(_DWORD *)(v1 + 8180) = 1092616192;
+        public float Unknown1FF8;     // offset: 8184, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(v1 + 8184) = 1065353216;
+        public float Unknown1FFC;     // offset: 8188, sz: 4, origin: 0x40000000, parsed: 2        // line:   *(_DWORD *)(v1 + 8188) = 0x40000000;
+        public float Unknown2000;     // offset: 0x2000, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(v1 + 0x2000) = 1065353216;
+        public float Unknown2004;     // offset: 8196, sz: 4, origin: 1058642330, parsed: 0.6        // line:   *(_DWORD *)(v1 + 8196) = 1058642330;
+        public float Unknown2008;     // offset: 8200, sz: 4, origin: 1056964608, parsed: 0.5        // line:   *(_DWORD *)(v1 + 8200) = 1056964608;
+        public float Unknown200C;     // offset: 8204, sz: 4, origin: 1058642330, parsed: 0.6        // line:   *(_DWORD *)(v1 + 8204) = 1058642330;
+        public float Unknown2010;     // offset: 8208, sz: 4, origin: 1045220557, parsed: 0.2        // line:   *(_DWORD *)(v1 + 8208) = 1045220557;
+        public float Unknown2014;     // offset: 8212, sz: 4, origin: 1128792064, parsed: 200        // line:   *(_DWORD *)(v1 + 8212) = 1128792064;
+        [NMS(Size = 0x80)]
+        public string Unknown2018;     // offset: 8216, sz: 128, origin:  Str1        // line:   strncpy((char *)(v1 + 8216), Str1, 0x80ui64);
+        // line:   *(_BYTE *)(v1 + 8343) = 0;
+        [NMS(Size = 0x80)]
+        public string Unknown2098;     // offset: 8344, sz: 128, origin:  Str1        // line:   strncpy((char *)(v1 + 8344), Str1, 0x80ui64);
+        // line:   *(_BYTE *)(v1 + 8471) = 0;
+        [NMS(Size = 0x80)]
+        public string Unknown2118;     // offset: 8472, sz: 128, origin:  "TEXTURES/EFFECTS/FULLSCREEN/HAZARDS/HOT.DDS"        // line:   strncpy((char *)(v1 + 8472), "TEXTURES/EFFECTS/FULLSCREEN/HAZARDS/HOT.DDS", 0x80ui64);
+        // line:   *(_BYTE *)(v1 + 8599) = 0;
+        [NMS(Size = 0x80)]
+        public string Unknown2198;     // offset: 8600, sz: 128, origin:  "TEXTURES/EFFECTS/FULLSCREEN/HAZARDS/COLD.DDS"        // line:   strncpy((char *)(v1 + 8600), "TEXTURES/EFFECTS/FULLSCREEN/HAZARDS/COLD.DDS", 0x80ui64);
+        // line:   *(_BYTE *)(v1 + 8727) = 0;
+        [NMS(Size = 0x80)]
+        public string Unknown2218;     // offset: 8728, sz: 128, origin:  "TEXTURES/EFFECTS/FULLSCREEN/HAZARDS/TOXIC.DDS"        // line:   strncpy((char *)(v1 + 8728), "TEXTURES/EFFECTS/FULLSCREEN/HAZARDS/TOXIC.DDS", 0x80ui64);
+        // line:   *(_BYTE *)(v1 + 8855) = 0;
+        [NMS(Size = 0x80)]
+        public string Unknown2298;     // offset: 8856, sz: 128, origin:  "TEXTURES/EFFECTS/FULLSCREEN/HAZARDS/RADIATION.DDS"        // line:   strncpy((char *)(v1 + 8856), "TEXTURES/EFFECTS/FULLSCREEN/HAZARDS/RADIATION.DDS", 0x80ui64);
+        // line:   *(_BYTE *)(v1 + 8983) = 0;
+        [NMS(Size = 0x80)]
+        public string Unknown2318;     // offset: 8984, sz: 128, origin:  Str1        // line:   strncpy((char *)(v1 + 8984), Str1, 0x80ui64);
+        // line:   *(_BYTE *)(v1 + 9111) = 0;
+        [NMS(Size = 0x80)]
+        public string Unknown2398;     // offset: 9112, sz: 128, origin:  Str1        // line:   strncpy((char *)(v1 + 9112), Str1, 0x80ui64);
+        // line:   *(_BYTE *)(v1 + 9239) = 0;
+        [NMS(Size = 0x80)]
+        public string Unknown2418;     // offset: 9240, sz: 128, origin:  "TEXTURES/EFFECTS/FULLSCREEN/HAZARDS/HOT.NORMAL.DDS"        // line:   strncpy((char *)(v1 + 9240), "TEXTURES/EFFECTS/FULLSCREEN/HAZARDS/HOT.NORMAL.DDS", 0x80ui64);
+        // line:   *(_BYTE *)(v1 + 9367) = 0;
+        [NMS(Size = 0x80)]
+        public string Unknown2498;     // offset: 9368, sz: 128, origin:  "TEXTURES/EFFECTS/FULLSCREEN/HAZARDS/COLD.NORMAL.DDS"        // line:   strncpy((char *)(v1 + 9368), "TEXTURES/EFFECTS/FULLSCREEN/HAZARDS/COLD.NORMAL.DDS", 0x80ui64);
+        // line:   *(_BYTE *)(v1 + 9495) = 0;
+        [NMS(Size = 0x80)]
+        public string Unknown2518;     // offset: 9496, sz: 128, origin:  "TEXTURES/EFFECTS/FULLSCREEN/HAZARDS/TOXIC.NORMAL.DDS"        // line:   strncpy((char *)(v1 + 9496), "TEXTURES/EFFECTS/FULLSCREEN/HAZARDS/TOXIC.NORMAL.DDS", 0x80ui64);
+        // line:   *(_BYTE *)(v1 + 9623) = 0;
+        [NMS(Size = 0x80)]
+        public string Unknown2598;     // offset: 9624, sz: 128, origin:  "TEXTURES/EFFECTS/FULLSCREEN/HAZARDS/HOT.NORMAL.DDS"        // line:   strncpy((char *)(v1 + 9624), "TEXTURES/EFFECTS/FULLSCREEN/HAZARDS/HOT.NORMAL.DDS", 0x80ui64);
+        // line:   *(_BYTE *)(v1 + 9751) = 0;
+        [NMS(Size = 0x80)]
+        public string Unknown2618;     // offset: 9752, sz: 128, origin:  Str1        // line:   strncpy((char *)(v1 + 9752), Str1, 0x80ui64);
+        // line:   *(_BYTE *)(v1 + 9879) = 0;
+        [NMS(Size = 0x80)]
+        public string Unknown2698;     // offset: 9880, sz: 128, origin:  Str1        // line:   strncpy((char *)(v1 + 9880), Str1, 0x80ui64);
+        // line:   *(_BYTE *)(v1 + 10007) = 0;
+        [NMS(Size = 0x80)]
+        public string Unknown2718;     // offset: 10008, sz: 128, origin:  "TEXTURES/EFFECTS/FULLSCREEN/HAZARDS/HOT.REFRACTION.DDS"        // line:   strncpy((char *)(v1 + 10008), "TEXTURES/EFFECTS/FULLSCREEN/HAZARDS/HOT.REFRACTION.DDS", 0x80ui64);
+        // line:   *(_BYTE *)(v1 + 10135) = 0;
+        [NMS(Size = 0x80)]
+        public string Unknown2798;     // offset: 10136, sz: 128, origin:  "TEXTURES/EFFECTS/FULLSCREEN/HAZARDS/COLD.REFRACTION.DDS"        // line:   strncpy((char *)(v1 + 10136), "TEXTURES/EFFECTS/FULLSCREEN/HAZARDS/COLD.REFRACTION.DDS", 0x80ui64);
+        // line:   *(_BYTE *)(v1 + 10263) = 0;
+        [NMS(Size = 0x80)]
+        public string Unknown2818;     // offset: 10264, sz: 128, origin:  "TEXTURES/EFFECTS/FULLSCREEN/HAZARDS/TOXIC.REFRACTION.DDS"        // line:   strncpy((char *)(v1 + 10264), "TEXTURES/EFFECTS/FULLSCREEN/HAZARDS/TOXIC.REFRACTION.DDS", 0x80ui64);
+        // line:   *(_BYTE *)(v1 + 10391) = 0;
+        [NMS(Size = 0x80)]
+        public string Unknown2898;     // offset: 10392, sz: 128, origin:  "TEXTURES/EFFECTS/FULLSCREEN/HAZARDS/HOT.REFRACTION.DDS"        // line:   strncpy((char *)(v1 + 10392), "TEXTURES/EFFECTS/FULLSCREEN/HAZARDS/HOT.REFRACTION.DDS", 0x80ui64);
+        // line:   *(_BYTE *)(v1 + 10519) = 0;
+        public float Unknown2918;     // offset: 10520, sz: 4, origin: 1056964608, parsed: 0.5        // line:   *(_DWORD *)(v1 + 10520) = 1056964608;
+
+        // missing 4 bytes at offset 10520
+        // could be padding, a undefined subroutine or a pointer accessing larger memory
+        [NMS(Size = 0x4, Ignore = true)]
+        public byte[] Padding291C;        // offset: 10524, sz: 4, comment: auto padding 
+
+        public float Unknown2920;     // offset: 10528, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(v1 + 10528) = 1065353216;
+        public float Unknown2924;     // offset: 10532, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(v1 + 10532) = 1065353216;
+        public float Unknown2928;     // offset: 10536, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(v1 + 10536) = 1065353216;
+        public float Unknown292C;     // offset: 10540, sz: 4, origin: 1050253722, parsed: 0.3        // line:   *(_DWORD *)(v1 + 10540) = 1050253722;
+        public float Unknown2930;     // offset: 10544, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(v1 + 10544) = 1065353216;
+        public float Unknown2934;     // offset: 10548, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(v1 + 10548) = 1065353216;
+        public float Unknown2938;     // offset: 10552, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(v1 + 10552) = 1065353216;
+        public float Unknown293C;     // offset: 10556, sz: 4, origin: 1058642330, parsed: 0.6        // line:   *(_DWORD *)(v1 + 10556) = 1058642330;
+        public float Unknown2940;     // offset: 10560, sz: 4, origin: 1064833122, parsed: 0.969        // line:   *(_DWORD *)(v1 + 10560) = 1064833122;
+        public float Unknown2944;     // offset: 10564, sz: 4, origin: 1048307565, parsed: 0.246        // line:   *(_DWORD *)(v1 + 10564) = 1048307565;
+        public float Unknown2948;     // offset: 10568, sz: 4, origin: 1048307565, parsed: 0.246        // line:   *(_DWORD *)(v1 + 10568) = 1048307565;
+        public float Unknown294C;     // offset: 10572, sz: 4, origin: 1056964608, parsed: 0.5        // line:   *(_DWORD *)(v1 + 10572) = 1056964608;
+        public float Unknown2950;     // offset: 10576, sz: 4, origin: 1059430859, parsed: 0.647        // line:   *(_DWORD *)(v1 + 10576) = 1059430859;
+        public float Unknown2954;     // offset: 10580, sz: 4, origin: 1041865114, parsed: 0.15        // line:   *(_DWORD *)(v1 + 10580) = 1041865114;
+        public float Unknown2958;     // offset: 10584, sz: 4, origin: 1041865114, parsed: 0.15        // line:   *(_DWORD *)(v1 + 10584) = 1041865114;
+        public float Unknown295C;     // offset: 10588, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(v1 + 10588) = 1065353216;
+        public float Unknown2960;     // offset: 10592, sz: 4, origin: 1064262697, parsed: 0.935        // line:   *(_DWORD *)(v1 + 10592) = 1064262697;
+        public float Unknown2964;     // offset: 10596, sz: 4, origin: 1064011039, parsed: 0.92        // line:   *(_DWORD *)(v1 + 10596) = 1064011039;
+        public float Unknown2968;     // offset: 10600, sz: 4, origin: 1063977484, parsed: 0.918        // line:   *(_DWORD *)(v1 + 10600) = 1063977484;
+        public float Unknown296C;     // offset: 10604, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(v1 + 10604) = 1065353216;
+        public float Unknown2970;     // offset: 10608, sz: 4, origin: 1064833122, parsed: 0.969        // line:   *(_DWORD *)(v1 + 10608) = 1064833122;
+        public float Unknown2974;     // offset: 10612, sz: 4, origin: 1048307565, parsed: 0.246        // line:   *(_DWORD *)(v1 + 10612) = 1048307565;
+        public float Unknown2978;     // offset: 10616, sz: 4, origin: 1048307565, parsed: 0.246        // line:   *(_DWORD *)(v1 + 10616) = 1048307565;
+        public float Unknown297C;     // offset: 10620, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(v1 + 10620) = 1065353216;
+        public float Unknown2980;     // offset: 10624, sz: 4, origin: 1055320441, parsed: 0.451        // line:   *(_DWORD *)(v1 + 10624) = 1055320441;
+        public float Unknown2984;     // offset: 10628, sz: 4, origin: 1023879938, parsed: 0.033        // line:   *(_DWORD *)(v1 + 10628) = 1023879938;
+        public float Unknown2988;     // offset: 10632, sz: 4, origin: 1023879938, parsed: 0.033        // line:   *(_DWORD *)(v1 + 10632) = 1023879938;
+        public float Unknown298C;     // offset: 10636, sz: 4, origin: 1045220557, parsed: 0.2        // line:   *(_DWORD *)(v1 + 10636) = 1045220557;
+        public float Unknown2990;     // offset: 10640, sz: 4, origin: 1064950563, parsed: 0.976        // line:   *(_DWORD *)(v1 + 10640) = 1064950563;
+        public float Unknown2994;     // offset: 10644, sz: 4, origin: 1045824537, parsed: 0.209        // line:   *(_DWORD *)(v1 + 10644) = 1045824537;
+        public float Unknown2998;     // offset: 10648, sz: 4, origin: 1045824537, parsed: 0.209        // line:   *(_DWORD *)(v1 + 10648) = 1045824537;
+        public float Unknown299C;     // offset: 10652, sz: 4, origin: 1053609165, parsed: 0.4        // line:   *(_DWORD *)(v1 + 10652) = 1053609165;
+        public float Unknown29A0;     // offset: 10656, sz: 4, origin: 1148682240, parsed: 990        // line:   *(_DWORD *)(v1 + 10656) = 1148682240;
+        public float Unknown29A4;     // offset: 10660, sz: 4, origin: 1135869952, parsed: 360        // line:   *(_DWORD *)(v1 + 10660) = 1135869952;
+        public float Unknown29A8;     // offset: 10664, sz: 4, origin: 1092616192, parsed: 10        // line:   *(_DWORD *)(v1 + 10664) = 1092616192;
+        public float Unknown29AC;     // offset: 10668, sz: 4, origin: -1027080192, parsed: -100        // line:   *(_DWORD *)(v1 + 10668) = -1027080192;
+        public float Unknown29B0;     // offset: 10672, sz: 4, origin: 1142292480, parsed: 600        // line:   *(_DWORD *)(v1 + 10672) = 1142292480;
+        public float Unknown29B4;     // offset: 10676, sz: 4, origin: 1128792064, parsed: 200        // line:   *(_DWORD *)(v1 + 10676) = 1128792064;
+        public float Unknown29B8;     // offset: 10680, sz: 4, origin: -1028390912, parsed: -90        // line:   *(_DWORD *)(v1 + 10680) = -1028390912;
+        public float Unknown29BC;     // offset: 10684, sz: 4, origin: 0i64, parsed: 0, comment: unaligned to 8 bytes! two packed floats in a QWORD?(1)
+        public float Unknown29C0;     // offset: 10688, sz: 4, origin: 0i64, parsed: 0, comment: unaligned to 8 bytes! two packed floats in a QWORD?(2)        // line:   *(_QWORD *)(v1 + 10684) = 0i64;
+        public float Unknown29C4;     // offset: 10692, sz: 4, origin: 1117782016, parsed: 80        // line:   *(_DWORD *)(v1 + 10692) = 1117782016;
+        public float Unknown29C8;     // offset: 10696, sz: 4, origin: 1056964608, parsed: 0.5        // line:   *(_DWORD *)(v1 + 10696) = 1056964608;
+        public float Unknown29CC;     // offset: 10700, sz: 4, origin: 1058642330, parsed: 0.6        // line:   *(_DWORD *)(v1 + 10700) = 1058642330;
+        public float Unknown29D0;     // offset: 10704, sz: 4, origin: 1064514355, parsed: 0.95        // line:   *(_DWORD *)(v1 + 10704) = 1064514355;
+        public float Unknown29D4;     // offset: 10708, sz: 4, origin: 1117782016, parsed: 80        // line:   *(_DWORD *)(v1 + 10708) = 1117782016;
+        public float Unknown29D8;     // offset: 10712, sz: 4, origin: 1148846080, parsed: 1000        // line:   *(_DWORD *)(v1 + 10712) = 1148846080;
+        public float Unknown29DC;     // offset: 10716, sz: 4, origin: 1056964608, parsed: 0.5        // line:   *(_DWORD *)(v1 + 10716) = 1056964608;
+        public GcModelViewCollection Template29E0;     // offset: 10720, sz: 1456, origin: sub_140162E50(v1 + 10720);, comment: call sub        // line:   sub_140162E50(v1 + 10720);
+        public float Unknown2F90;     // offset: 12176, sz: 4, origin: 1062433980, parsed: 0.826        // line:   *(_DWORD *)(v1 + 12176) = 1062433980;
+        public float Unknown2F94;     // offset: 12180, sz: 4, origin: 1062215877, parsed: 0.813        // line:   *(_DWORD *)(v1 + 12180) = 1062215877;
+        public float Unknown2F98;     // offset: 12184, sz: 4, origin: 1062182322, parsed: 0.811        // line:   *(_DWORD *)(v1 + 12184) = 1062182322;
+        public float Unknown2F9C;     // offset: 12188, sz: 4, origin: 1063675494, parsed: 0.9        // line:   *(_DWORD *)(v1 + 12188) = 1063675494;
+        public float Unknown2FA0;     // offset: 12192, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(v1 + 12192) = 1065353216;
+        public float Unknown2FA4;     // offset: 12196, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(v1 + 12196) = 1065353216;
+        public float Unknown2FA8;     // offset: 12200, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(v1 + 12200) = 1065353216;
+        public float Unknown2FAC;     // offset: 12204, sz: 4, origin: 1063675494, parsed: 0.9        // line:   *(_DWORD *)(v1 + 12204) = 1063675494;
+        public float Unknown2FB0;     // offset: 12208, sz: 4, origin: 1065353216i64, parsed: 1, comment: unaligned to 8 bytes! two packed floats in a QWORD?(1)
+        public float Unknown2FB4;     // offset: 12212, sz: 4, origin: 1065353216i64, parsed: 0, comment: unaligned to 8 bytes! two packed floats in a QWORD?(2)        // line:   *(_QWORD *)(v1 + 12208) = 1065353216i64;
+        public float Unknown2FB8;     // offset: 12216, sz: 4, origin: 0, parsed: 0        // line:   *(_DWORD *)(v1 + 12216) = 0;
+        public float Unknown2FBC;     // offset: 12220, sz: 4, origin: 1063675494, parsed: 0.9        // line:   *(_DWORD *)(v1 + 12220) = 1063675494;
+        public float Unknown2FC0;     // offset: 12224, sz: 4, origin: 1056964608, parsed: 0.5        // line:   *(_DWORD *)(v1 + 12224) = 1056964608;
+        public float Unknown2FC4;     // offset: 12228, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(v1 + 12228) = 1065353216;
+        // line: // "fast actions" modded value 1
+        public float Unknown2FC8;     // offset: 12232, sz: 4, origin: 1056964608, parsed: 0.5        // line:   *(_DWORD *)(v1 + 12232) = 1056964608;
+        public float Unknown2FCC;     // offset: 12236, sz: 4, origin: 1051931443, parsed: 0.35        // line:   *(_DWORD *)(v1 + 12236) = 1051931443;
+        // line: // "fast actions" modded value 2
+        public float Unknown2FD0;     // offset: 12240, sz: 4, origin: 1060320051i64, parsed: 0.7, comment: unaligned to 8 bytes! two packed floats in a QWORD?(1)
+        public float Unknown2FD4;     // offset: 12244, sz: 4, origin: 1060320051i64, parsed: 0, comment: unaligned to 8 bytes! two packed floats in a QWORD?(2)        // line:   *(_QWORD *)(v1 + 12240) = 1060320051i64;
+        public float Unknown2FD8;     // offset: 12248, sz: 4, origin: 1103101952i64, parsed: 24, comment: unaligned to 8 bytes! two packed floats in a QWORD?(1)
+        public float Unknown2FDC;     // offset: 12252, sz: 4, origin: 1103101952i64, parsed: 0, comment: unaligned to 8 bytes! two packed floats in a QWORD?(2)        // line:   *(_QWORD *)(v1 + 12248) = 1103101952i64;
+        public float Unknown2FE0;     // offset: 12256, sz: 4, origin: 1077936128, parsed: 3        // line:   *(_DWORD *)(v1 + 12256) = 1077936128;
+        public float Unknown2FE4;     // offset: 12260, sz: 4, origin: 1091567616, parsed: 9        // line:   *(_DWORD *)(v1 + 12260) = 1091567616;
+        public float Unknown2FE8;     // offset: 12264, sz: 4, origin: 1053609165, parsed: 0.4        // line:   *(_DWORD *)(v1 + 12264) = 1053609165;
+        public float Unknown2FEC;     // offset: 12268, sz: 4, origin: 1045220557, parsed: 0.2        // line:   *(_DWORD *)(v1 + 12268) = 1045220557;
+        public float Unknown2FF0;     // offset: 12272, sz: 4, origin: 1053609165, parsed: 0.4        // line:   *(_DWORD *)(v1 + 12272) = 1053609165;
+        public float Unknown2FF4;     // offset: 12276, sz: 4, origin: 1045220557, parsed: 0.2        // line:   *(_DWORD *)(v1 + 12276) = 1045220557;
+        public float Unknown2FF8;     // offset: 12280, sz: 4, origin: 1077936128, parsed: 3        // line:   *(_DWORD *)(v1 + 12280) = 1077936128;
+        public float Unknown2FFC;     // offset: 12284, sz: 4, origin: 1090519040i64, parsed: 8, comment: unaligned to 8 bytes! two packed floats in a QWORD?(1)
+        public float Unknown3000;     // offset: 12288, sz: 4, origin: 1090519040i64, parsed: 0, comment: unaligned to 8 bytes! two packed floats in a QWORD?(2)        // line:   *(_QWORD *)(v1 + 12284) = 1090519040i64;
+        public float Unknown3004;     // offset: 12292, sz: 4, origin: 0i64, parsed: 0, comment: unaligned to 8 bytes! two packed floats in a QWORD?(1)
+        public float Unknown3008;     // offset: 12296, sz: 4, origin: 0i64, parsed: 0, comment: unaligned to 8 bytes! two packed floats in a QWORD?(2)        // line:   *(_QWORD *)(v1 + 12292) = 0i64;
+        public float Unknown300C;     // offset: 12300, sz: 4, origin: 1069547520, parsed: 1.5        // line:   *(_DWORD *)(v1 + 12300) = 1069547520;
+        public float Unknown3010;     // offset: 12304, sz: 4, origin: 1045220557, parsed: 0.2        // line:   *(_DWORD *)(v1 + 12304) = 1045220557;
+        public float Unknown3014;     // offset: 12308, sz: 4, origin: 1050253722i64, parsed: 0.3, comment: unaligned to 8 bytes! two packed floats in a QWORD?(1)
+        public float Unknown3018;     // offset: 12312, sz: 4, origin: 1050253722i64, parsed: 0, comment: unaligned to 8 bytes! two packed floats in a QWORD?(2)        // line:   *(_QWORD *)(v1 + 12308) = 1050253722i64;
+        public float Unknown301C;     // offset: 12316, sz: 4, origin: 0, parsed: 0        // line:   *(_DWORD *)(v1 + 12316) = 0;
+        public float Unknown3020;     // offset: 12320, sz: 4, origin: 1159479296, parsed: 2500        // line:   *(_DWORD *)(v1 + 12320) = 1159479296;
+        public float Unknown3024;     // offset: 12324, sz: 4, origin: 1140457472, parsed: 500        // line:   *(_DWORD *)(v1 + 12324) = 1140457472;
+        public float Unknown3028;     // offset: 12328, sz: 4, origin: 1077936128, parsed: 3        // line:   *(_DWORD *)(v1 + 12328) = 1077936128;
+        public int Unknown302C;     // offset: 12332, sz: 4, origin: 430, parsed: 430        // line:   *(_DWORD *)(v1 + 12332) = 430;
+        public float Unknown3030;     // offset: 12336, sz: 4, origin: 1140457472, parsed: 500        // line:   *(_DWORD *)(v1 + 12336) = 1140457472;
+        public float Unknown3034;     // offset: 12340, sz: 4, origin: 1051931443, parsed: 0.35        // line:   *(_DWORD *)(v1 + 12340) = 1051931443;
+        public float Unknown3038;     // offset: 12344, sz: 4, origin: 1008981770, parsed: 0.01        // line:   *(_DWORD *)(v1 + 12344) = 1008981770;
+        public float Unknown303C;     // offset: 12348, sz: 4, origin: 1045220557, parsed: 0.2        // line:   *(_DWORD *)(v1 + 12348) = 1045220557;
+        public float Unknown3040;     // offset: 12352, sz: 4, origin: 1050253722i64, parsed: 0.3, comment: unaligned to 8 bytes! two packed floats in a QWORD?(1)
+        public float Unknown3044;     // offset: 12356, sz: 4, origin: 1050253722i64, parsed: 0, comment: unaligned to 8 bytes! two packed floats in a QWORD?(2)        // line:   *(_QWORD *)(v1 + 12352) = 1050253722i64;
+        public float Unknown3048;     // offset: 12360, sz: 4, origin: 1101004800, parsed: 20        // line:   *(_DWORD *)(v1 + 12360) = 1101004800;
+        public float Unknown304C;     // offset: 12364, sz: 4, origin: 1101004800, parsed: 20        // line:   *(_DWORD *)(v1 + 12364) = 1101004800;
+        public float Unknown3050;     // offset: 12368, sz: 4, origin: 1036831949, parsed: 0.1        // line:   *(_DWORD *)(v1 + 12368) = 1036831949;
+        public float Unknown3054;     // offset: 12372, sz: 4, origin: 1120403456, parsed: 100        // line:   *(_DWORD *)(v1 + 12372) = 1120403456;
+        public float Unknown3058;     // offset: 12376, sz: 4, origin: 1107296256, parsed: 32        // line:   *(_DWORD *)(v1 + 12376) = 1107296256;
+        public float Unknown305C;     // offset: 12380, sz: 4, origin: 1109393408, parsed: 40        // line:   *(_DWORD *)(v1 + 12380) = 1109393408;
+        public float Unknown3060;     // offset: 12384, sz: 4, origin: 0x40000000, parsed: 2        // line:   *(_DWORD *)(v1 + 12384) = 0x40000000;
+        public float Unknown3064;     // offset: 12388, sz: 4, origin: 1097859072, parsed: 15        // line:   *(_DWORD *)(v1 + 12388) = 1097859072;
+        public float Unknown3068;     // offset: 12392, sz: 4, origin: 1053609165, parsed: 0.4        // line:   *(_DWORD *)(v1 + 12392) = 1053609165;
+        public float Unknown306C;     // offset: 12396, sz: 4, origin: 1109393408, parsed: 40        // line:   *(_DWORD *)(v1 + 12396) = 1109393408;
+        public float Unknown3070;     // offset: 12400, sz: 4, origin: 1117782016, parsed: 80        // line:   *(_DWORD *)(v1 + 12400) = 1117782016;
+
+        // missing 12 bytes at offset 12400
+        // could be padding, a undefined subroutine or a pointer accessing larger memory
+        [NMS(Size = 0xC, Ignore = true)]
+        public byte[] Padding3074;        // offset: 12404, sz: 12, comment: auto padding 
+
+        public float Unknown3080;     // offset: 12416, sz: 4, origin: 1059682517, parsed: 0.662        // line:   *(_DWORD *)(v1 + 12416) = 1059682517;
+        public float Unknown3084;     // offset: 12420, sz: 4, origin: 1041663787i64, parsed: 0.147, comment: unaligned to 8 bytes! two packed floats in a QWORD?(1)
+        public float Unknown3088;     // offset: 12424, sz: 4, origin: 1041663787i64, parsed: 0, comment: unaligned to 8 bytes! two packed floats in a QWORD?(2)        // line:   *(_QWORD *)(v1 + 12420) = 1041663787i64;
+        public float Unknown308C;     // offset: 12428, sz: 4, origin: 1063675494, parsed: 0.9        // line:   *(_DWORD *)(v1 + 12428) = 1063675494;
+        public float Unknown3090;     // offset: 12432, sz: 4, origin: 1064715682, parsed: 0.962        // line:   *(_DWORD *)(v1 + 12432) = 1064715682;
+        public float Unknown3094;     // offset: 12436, sz: 4, origin: 1045153448, parsed: 0.199        // line:   *(_DWORD *)(v1 + 12436) = 1045153448;
+        public float Unknown3098;     // offset: 12440, sz: 4, origin: 1045153448, parsed: 0.199        // line:   *(_DWORD *)(v1 + 12440) = 1045153448;
+        public float Unknown309C;     // offset: 12444, sz: 4, origin: 1063675494, parsed: 0.9        // line:   *(_DWORD *)(v1 + 12444) = 1063675494;
+        public float Unknown30A0;     // offset: 12448, sz: 4, origin: 0x40000000, parsed: 2        // line:   *(_DWORD *)(v1 + 12448) = 0x40000000;
+        public float Unknown30A4;     // offset: 12452, sz: 4, origin: 1061997773, parsed: 0.8        // line:   *(_DWORD *)(v1 + 12452) = 1061997773;
+        public float Unknown30A8;     // offset: 12456, sz: 4, origin: 1092616192, parsed: 10        // line:   *(_DWORD *)(v1 + 12456) = 1092616192;
+        public float Unknown30AC;     // offset: 12460, sz: 4, origin: 1110704128, parsed: 45        // line:   *(_DWORD *)(v1 + 12460) = 1110704128;
+        public float Unknown30B0;     // offset: 12464, sz: 4, origin: 1077936128, parsed: 3        // line:   *(_DWORD *)(v1 + 12464) = 1077936128;
+        public float Unknown30B4;     // offset: 12468, sz: 4, origin: 1041865114, parsed: 0.15        // line:   *(_DWORD *)(v1 + 12468) = 1041865114;
+
+        // missing 8 bytes at offset 12468
+        // could be padding, a undefined subroutine or a pointer accessing larger memory
+        [NMS(Size = 0x8, Ignore = true)]
+        public byte[] Padding30B8;        // offset: 12472, sz: 8, comment: auto padding 
+
+        public float Unknown30C0;     // offset: 12480, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(v1 + 12480) = 1065353216;
+        public float Unknown30C4;     // offset: 12484, sz: 4, origin: 1046428516, parsed: 0.218        // line:   *(_DWORD *)(v1 + 12484) = 1046428516;
+        public float Unknown30C8;     // offset: 12488, sz: 4, origin: 1056595509, parsed: 0.489        // line:   *(_DWORD *)(v1 + 12488) = 1056595509;
+        public float Unknown30CC;     // offset: 12492, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(v1 + 12492) = 1065353216;
+        public float Unknown30D0;     // offset: 12496, sz: 4, origin: 1148190720, parsed: 960        // line:   *(_DWORD *)(v1 + 12496) = 1148190720;
+        public float Unknown30D4;     // offset: 12500, sz: 4, origin: -1009745920, parsed: -417        // line:   *(_DWORD *)(v1 + 12500) = -1009745920;
+        public float Unknown30D8;     // offset: 12504, sz: 4, origin: 1139146752, parsed: 460        // line:   *(_DWORD *)(v1 + 12504) = 1139146752;
+        public float Unknown30DC;     // offset: 12508, sz: 4, origin: 1102053376, parsed: 22        // line:   *(_DWORD *)(v1 + 12508) = 1102053376;
+        public float Unknown30E0;     // offset: 12512, sz: 4, origin: 1071877624, parsed: 1.77777        // line:   *(_DWORD *)(v1 + 12512) = 1071877624;
+        public float Unknown30E4;     // offset: 12516, sz: 4, origin: 1050253722, parsed: 0.3        // line:   *(_DWORD *)(v1 + 12516) = 1050253722;
+        public float Unknown30E8;     // offset: 12520, sz: 4, origin: 1053609165, parsed: 0.4        // line:   *(_DWORD *)(v1 + 12520) = 1053609165;
+        public float Unknown30EC;     // offset: 12524, sz: 4, origin: 1045220557, parsed: 0.2        // line:   *(_DWORD *)(v1 + 12524) = 1045220557;
+        public float Unknown30F0;     // offset: 12528, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(v1 + 12528) = 1065353216;
+        public float Unknown30F4;     // offset: 12532, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(v1 + 12532) = 1065353216;
+        public float Unknown30F8;     // offset: 12536, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(v1 + 12536) = 1065353216;
+        public float Unknown30FC;     // offset: 12540, sz: 4, origin: 1036831949, parsed: 0.1        // line:   *(_DWORD *)(v1 + 12540) = 1036831949;
+        public float Unknown3100;     // offset: 12544, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(v1 + 12544) = 1065353216;
+        public float Unknown3104;     // offset: 12548, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(v1 + 12548) = 1065353216;
+        public float Unknown3108;     // offset: 12552, sz: 4, origin: 1056964608, parsed: 0.5        // line:   *(_DWORD *)(v1 + 12552) = 1056964608;
+        public float Unknown310C;     // offset: 12556, sz: 4, origin: 1056964608, parsed: 0.5        // line:   *(_DWORD *)(v1 + 12556) = 1056964608;
+        public float Unknown3110;     // offset: 12560, sz: 4, origin: 1045220557, parsed: 0.2        // line:   *(_DWORD *)(v1 + 12560) = 1045220557;
+        public float Unknown3114;     // offset: 12564, sz: 4, origin: 1036831949, parsed: 0.1        // line:   *(_DWORD *)(v1 + 12564) = 1036831949;
+        public float Unknown3118;     // offset: 12568, sz: 4, origin: 1176256512, parsed: 10000        // line:   *(_DWORD *)(v1 + 12568) = 1176256512;
+        public float Unknown311C;     // offset: 12572, sz: 4, origin: 1092616192, parsed: 10        // line:   *(_DWORD *)(v1 + 12572) = 1092616192;
+        public float Unknown3120;     // offset: 12576, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(v1 + 12576) = 1065353216;
+        public float Unknown3124;     // offset: 12580, sz: 4, origin: 1119092736, parsed: 90        // line:   *(_DWORD *)(v1 + 12580) = 1119092736;
+        public float Unknown3128;     // offset: 12584, sz: 4, origin: 1121714176, parsed: 110        // line:   *(_DWORD *)(v1 + 12584) = 1121714176;
+        public float Unknown312C;     // offset: 12588, sz: 4, origin: 1066192077, parsed: 1.1        // line:   *(_DWORD *)(v1 + 12588) = 1066192077;
+        public float Unknown3130;     // offset: 12592, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(v1 + 12592) = 1065353216;
+        public float Unknown3134;     // offset: 12596, sz: 4, origin: 1091567616, parsed: 9        // line:   *(_DWORD *)(v1 + 12596) = 1091567616;
+        public float Unknown3138;     // offset: 12600, sz: 4, origin: 1056964608, parsed: 0.5        // line:   *(_DWORD *)(v1 + 12600) = 1056964608;
+        public float Unknown313C;     // offset: 12604, sz: 4, origin: -1036779520, parsed: -45        // line:   *(_DWORD *)(v1 + 12604) = -1036779520;
+        public float Unknown3140;     // offset: 12608, sz: 4, origin: -1020002304, parsed: -180        // line:   *(_DWORD *)(v1 + 12608) = -1020002304;
+
+        // missing 12 bytes at offset 12608
+        // could be padding, a undefined subroutine or a pointer accessing larger memory
+        [NMS(Size = 0xC, Ignore = true)]
+        public byte[] Padding3144;        // offset: 12612, sz: 12, comment: auto padding 
+
+        public float Unknown3150;     // offset: 12624, sz: 4, origin: 1068708659, parsed: 1.4        // line:   *(_DWORD *)(v1 + 12624) = 1068708659;
+        public float Unknown3154;     // offset: 12628, sz: 4, origin: 1060320051, parsed: 0.7        // line:   *(_DWORD *)(v1 + 12628) = 1060320051;
+        public float Unknown3158;     // offset: 12632, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(v1 + 12632) = 1065353216;
+
+        // missing 4 bytes at offset 12632
+        // could be padding, a undefined subroutine or a pointer accessing larger memory
+        [NMS(Size = 0x4, Ignore = true)]
+        public byte[] Padding315C;        // offset: 12636, sz: 4, comment: auto padding 
+
+        public float Unknown3160;     // offset: 12640, sz: 4, origin: 1065353216i64, parsed: 1, comment: unaligned to 8 bytes! two packed floats in a QWORD?(1)
+        public float Unknown3164;     // offset: 12644, sz: 4, origin: 1065353216i64, parsed: 0, comment: unaligned to 8 bytes! two packed floats in a QWORD?(2)        // line:   *(_QWORD *)(v1 + 12640) = 1065353216i64;
+        public float Unknown3168;     // offset: 12648, sz: 4, origin: 0, parsed: 0        // line:   *(_DWORD *)(v1 + 12648) = 0;
+        public float Unknown316C;     // offset: 12652, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(v1 + 12652) = 1065353216;
+        public float Unknown3170;     // offset: 12656, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(v1 + 12656) = 1065353216;
+        public float Unknown3174;     // offset: 12660, sz: 4, origin: 1059917398i64, parsed: 0.676, comment: unaligned to 8 bytes! two packed floats in a QWORD?(1)
+        public float Unknown3178;     // offset: 12664, sz: 4, origin: 1059917398i64, parsed: 0, comment: unaligned to 8 bytes! two packed floats in a QWORD?(2)        // line:   *(_QWORD *)(v1 + 12660) = 1059917398i64;
+        public float Unknown317C;     // offset: 12668, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(v1 + 12668) = 1065353216;
+        public float Unknown3180;     // offset: 12672, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(v1 + 12672) = 1065353216;
+        public float Unknown3184;     // offset: 12676, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(v1 + 12676) = 1065353216;
+        public float Unknown3188;     // offset: 12680, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(v1 + 12680) = 1065353216;
+        public float Unknown318C;     // offset: 12684, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(v1 + 12684) = 1065353216;
+        public float Unknown3190;     // offset: 12688, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(v1 + 12688) = 1065353216;
+        public float Unknown3194;     // offset: 12692, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(v1 + 12692) = 1065353216;
+        public float Unknown3198;     // offset: 12696, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(v1 + 12696) = 1065353216;
+        public float Unknown319C;     // offset: 12700, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(v1 + 12700) = 1065353216;
+        public float Unknown31A0;     // offset: 12704, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(v1 + 12704) = 1065353216;
+        public float Unknown31A4;     // offset: 12708, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(v1 + 12708) = 1065353216;
+        public float Unknown31A8;     // offset: 12712, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(v1 + 12712) = 1065353216;
+        public float Unknown31AC;     // offset: 12716, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(v1 + 12716) = 1065353216;
+        public float Unknown31B0;     // offset: 12720, sz: 4, origin: 1075838976, parsed: 2.5        // line:   *(_DWORD *)(v1 + 12720) = 1075838976;
+        public float Unknown31B4;     // offset: 12724, sz: 4, origin: 1092616192, parsed: 10        // line:   *(_DWORD *)(v1 + 12724) = 1092616192;
+        public float Unknown31B8;     // offset: 12728, sz: 4, origin: 1140457472, parsed: 500        // line:   *(_DWORD *)(v1 + 12728) = 1140457472;
+        public float Unknown31BC;     // offset: 12732, sz: 4, origin: 1176256512, parsed: 10000        // line:   *(_DWORD *)(v1 + 12732) = 1176256512;
+        public float Unknown31C0;     // offset: 12736, sz: 4, origin: 1068708659, parsed: 1.4        // line:   *(_DWORD *)(v1 + 12736) = 1068708659;
+        public float Unknown31C4;     // offset: 12740, sz: 4, origin: 1053609165, parsed: 0.4        // line:   *(_DWORD *)(v1 + 12740) = 1053609165;
+        public bool Unknown31C8;     // offset: 12744, sz: 1, origin: 0, parsed: 0        // line:   *(_BYTE *)(v1 + 12744) = 0;
+
+        // missing 7 bytes at offset 12744
+        // does 12744 contain a QWORD?
+        [NMS(Size = 0x7, Ignore = true)]
+        public byte[] Padding31C9;        // offset: 12745, sz: 7, comment: auto padding 
+
+        public float Unknown31D0;     // offset: 12752, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(v1 + 12752) = 1065353216;
+        public float Unknown31D4;     // offset: 12756, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(v1 + 12756) = 1065353216;
+        public float Unknown31D8;     // offset: 12760, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(v1 + 12760) = 1065353216;
+        public float Unknown31DC;     // offset: 12764, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(v1 + 12764) = 1065353216;
+        public float Unknown31E0;     // offset: 12768, sz: 4, origin: 1075838976, parsed: 2.5        // line:   *(_DWORD *)(v1 + 12768) = 1075838976;
+        public float Unknown31E4;     // offset: 12772, sz: 4, origin: 1092616192, parsed: 10        // line:   *(_DWORD *)(v1 + 12772) = 1092616192;
+        public float Unknown31E8;     // offset: 12776, sz: 4, origin: 1140457472, parsed: 500        // line:   *(_DWORD *)(v1 + 12776) = 1140457472;
+        public float Unknown31EC;     // offset: 12780, sz: 4, origin: 1176256512, parsed: 10000        // line:   *(_DWORD *)(v1 + 12780) = 1176256512;
+        public float Unknown31F0;     // offset: 12784, sz: 4, origin: 1068708659, parsed: 1.4        // line:   *(_DWORD *)(v1 + 12784) = 1068708659;
+        public float Unknown31F4;     // offset: 12788, sz: 4, origin: 1053609165, parsed: 0.4        // line:   *(_DWORD *)(v1 + 12788) = 1053609165;
+        public bool Unknown31F8;     // offset: 12792, sz: 1, origin: 0, parsed: 0        // line:   *(_BYTE *)(v1 + 12792) = 0;
+
+        // missing 7 bytes at offset 12792
+        // does 12792 contain a QWORD?
+        [NMS(Size = 0x7, Ignore = true)]
+        public byte[] Padding31F9;        // offset: 12793, sz: 7, comment: auto padding 
+
+        public float Unknown3200;     // offset: 12800, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(v1 + 12800) = 1065353216;
+        public float Unknown3204;     // offset: 12804, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(v1 + 12804) = 1065353216;
+        public float Unknown3208;     // offset: 12808, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(v1 + 12808) = 1065353216;
+        public float Unknown320C;     // offset: 12812, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(v1 + 12812) = 1065353216;
+        public float Unknown3210;     // offset: 12816, sz: 4, origin: 1075838976, parsed: 2.5        // line:   *(_DWORD *)(v1 + 12816) = 1075838976;
+        public float Unknown3214;     // offset: 12820, sz: 4, origin: 1092616192, parsed: 10        // line:   *(_DWORD *)(v1 + 12820) = 1092616192;
+        public float Unknown3218;     // offset: 12824, sz: 4, origin: 1140457472, parsed: 500        // line:   *(_DWORD *)(v1 + 12824) = 1140457472;
+        public float Unknown321C;     // offset: 12828, sz: 4, origin: 1176256512, parsed: 10000        // line:   *(_DWORD *)(v1 + 12828) = 1176256512;
+        public float Unknown3220;     // offset: 12832, sz: 4, origin: 1068708659, parsed: 1.4        // line:   *(_DWORD *)(v1 + 12832) = 1068708659;
+        public float Unknown3224;     // offset: 12836, sz: 4, origin: 1053609165, parsed: 0.4        // line:   *(_DWORD *)(v1 + 12836) = 1053609165;
+        public bool Unknown3228;     // offset: 12840, sz: 1, origin: 0, parsed: 0        // line:   *(_BYTE *)(v1 + 12840) = 0;
+
+        // missing 7 bytes at offset 12840
+        // does 12840 contain a QWORD?
+        [NMS(Size = 0x7, Ignore = true)]
+        public byte[] Padding3229;        // offset: 12841, sz: 7, comment: auto padding 
+
+        public float Unknown3230;     // offset: 12848, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(v1 + 12848) = 1065353216;
+        public float Unknown3234;     // offset: 12852, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(v1 + 12852) = 1065353216;
+        public float Unknown3238;     // offset: 12856, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(v1 + 12856) = 1065353216;
+        public float Unknown323C;     // offset: 12860, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(v1 + 12860) = 1065353216;
+        public float Unknown3240;     // offset: 12864, sz: 4, origin: 1075838976, parsed: 2.5        // line:   *(_DWORD *)(v1 + 12864) = 1075838976;
+        public float Unknown3244;     // offset: 12868, sz: 4, origin: 1092616192, parsed: 10        // line:   *(_DWORD *)(v1 + 12868) = 1092616192;
+        public float Unknown3248;     // offset: 12872, sz: 4, origin: 1140457472, parsed: 500        // line:   *(_DWORD *)(v1 + 12872) = 1140457472;
+        public float Unknown324C;     // offset: 12876, sz: 4, origin: 1176256512, parsed: 10000        // line:   *(_DWORD *)(v1 + 12876) = 1176256512;
+        public float Unknown3250;     // offset: 12880, sz: 4, origin: 1068708659, parsed: 1.4        // line:   *(_DWORD *)(v1 + 12880) = 1068708659;
+        public float Unknown3254;     // offset: 12884, sz: 4, origin: 1053609165, parsed: 0.4        // line:   *(_DWORD *)(v1 + 12884) = 1053609165;
+        public bool Unknown3258;     // offset: 12888, sz: 1, origin: 0, parsed: 0        // line:   *(_BYTE *)(v1 + 12888) = 0;
+
+        // missing 7 bytes at offset 12888
+        // does 12888 contain a QWORD?
+        [NMS(Size = 0x7, Ignore = true)]
+        public byte[] Padding3259;        // offset: 12889, sz: 7, comment: auto padding 
+
+        public float Unknown3260;     // offset: 12896, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(v1 + 12896) = 1065353216;
+        public float Unknown3264;     // offset: 12900, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(v1 + 12900) = 1065353216;
+        public float Unknown3268;     // offset: 12904, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(v1 + 12904) = 1065353216;
+        public float Unknown326C;     // offset: 12908, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(v1 + 12908) = 1065353216;
+        public float Unknown3270;     // offset: 12912, sz: 4, origin: 1075838976, parsed: 2.5        // line:   *(_DWORD *)(v1 + 12912) = 1075838976;
+        public float Unknown3274;     // offset: 12916, sz: 4, origin: 1092616192, parsed: 10        // line:   *(_DWORD *)(v1 + 12916) = 1092616192;
+        public float Unknown3278;     // offset: 12920, sz: 4, origin: 1140457472, parsed: 500        // line:   *(_DWORD *)(v1 + 12920) = 1140457472;
+        public float Unknown327C;     // offset: 12924, sz: 4, origin: 1176256512, parsed: 10000        // line:   *(_DWORD *)(v1 + 12924) = 1176256512;
+        public float Unknown3280;     // offset: 12928, sz: 4, origin: 1068708659, parsed: 1.4        // line:   *(_DWORD *)(v1 + 12928) = 1068708659;
+        public float Unknown3284;     // offset: 12932, sz: 4, origin: 1053609165, parsed: 0.4        // line:   *(_DWORD *)(v1 + 12932) = 1053609165;
+        public bool Unknown3288;     // offset: 12936, sz: 1, origin: 0, parsed: 0        // line:   *(_BYTE *)(v1 + 12936) = 0;
+
+        // missing 7 bytes at offset 12936
+        // does 12936 contain a QWORD?
+        [NMS(Size = 0x7, Ignore = true)]
+        public byte[] Padding3289;        // offset: 12937, sz: 7, comment: auto padding 
+
+        public float Unknown3290;     // offset: 12944, sz: 4, origin: 1039516303, parsed: 0.12        // line:   *(_DWORD *)(v1 + 12944) = 1039516303;
+        public float Unknown3294;     // offset: 12948, sz: 4, origin: -1088841318, parsed: -0.6        // line:   *(_DWORD *)(v1 + 12948) = -1088841318;
+        public float Unknown3298;     // offset: 12952, sz: 4, origin: 1061158912, parsed: 0.75        // line:   *(_DWORD *)(v1 + 12952) = 1061158912;
+        public float Unknown329C;     // offset: 12956, sz: 4, origin: 1028443341, parsed: 0.05        // line:   *(_DWORD *)(v1 + 12956) = 1028443341;
+        public float Unknown32A0;     // offset: 12960, sz: 4, origin: -1110651699, parsed: -0.1        // line:   *(_DWORD *)(v1 + 12960) = -1110651699;
+        public float Unknown32A4;     // offset: 12964, sz: 4, origin: 1017370378, parsed: 0.02        // line:   *(_DWORD *)(v1 + 12964) = 1017370378;
+        public float Unknown32A8;     // offset: 12968, sz: 4, origin: 1041865114, parsed: 0.15        // line:   *(_DWORD *)(v1 + 12968) = 1041865114;
+        public float Unknown32AC;     // offset: 12972, sz: 4, origin: 0x40000000, parsed: 2        // line:   *(_DWORD *)(v1 + 12972) = 0x40000000;
+        public float Unknown32B0;     // offset: 12976, sz: 4, origin: -1100920914, parsed: -0.22        // line:   *(_DWORD *)(v1 + 12976) = -1100920914;
+        public float Unknown32B4;     // offset: 12980, sz: 4, origin: 1036831949, parsed: 0.1        // line:   *(_DWORD *)(v1 + 12980) = 1036831949;
+        public float Unknown32B8;     // offset: 12984, sz: 4, origin: -1095887749, parsed: -0.34        // line:   *(_DWORD *)(v1 + 12984) = -1095887749;
+        public float Unknown32BC;     // offset: 12988, sz: 4, origin: 1045220557, parsed: 0.2        // line:   *(_DWORD *)(v1 + 12988) = 1045220557;
+        public float Unknown32C0;     // offset: 12992, sz: 4, origin: 1061158912, parsed: 0.75        // line:   *(_DWORD *)(v1 + 12992) = 1061158912;
+
+        // missing 12 bytes at offset 12992
+        // could be padding, a undefined subroutine or a pointer accessing larger memory
+        [NMS(Size = 0xC, Ignore = true)]
+        public byte[] Padding32C4;        // offset: 12996, sz: 12, comment: auto padding 
+
+        public float Unknown32D0;     // offset: 13008, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(v1 + 13008) = 1065353216;
+        public float Unknown32D4;     // offset: 13012, sz: 4, origin: 1055756648, parsed: 0.464        // line:   *(_DWORD *)(v1 + 13012) = 1055756648;
+        public float Unknown32D8;     // offset: 13016, sz: 4, origin: 1065202221, parsed: 0.991        // line:   *(_DWORD *)(v1 + 13016) = 1065202221;
+        public float Unknown32DC;     // offset: 13020, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(v1 + 13020) = 1065353216;
+        public float Unknown32E0;     // offset: 13024, sz: 4, origin: 1063205732, parsed: 0.872        // line:   *(_DWORD *)(v1 + 13024) = 1063205732;
+        public float Unknown32E4;     // offset: 13028, sz: 4, origin: 1063927153, parsed: 0.915        // line:   *(_DWORD *)(v1 + 13028) = 1063927153;
+        public float Unknown32E8;     // offset: 13032, sz: 4, origin: 1064715682, parsed: 0.962        // line:   *(_DWORD *)(v1 + 13032) = 1064715682;
+        public float Unknown32EC;     // offset: 13036, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(v1 + 13036) = 1065353216;
+        public float Unknown32F0;     // offset: 13040, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(v1 + 13040) = 1065353216;
+        public float Unknown32F4;     // offset: 13044, sz: 4, origin: 1061360239, parsed: 0.762        // line:   *(_DWORD *)(v1 + 13044) = 1061360239;
+        public float Unknown32F8;     // offset: 13048, sz: 4, origin: 1046428516, parsed: 0.218        // line:   *(_DWORD *)(v1 + 13048) = 1046428516;
+        public float Unknown32FC;     // offset: 13052, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(v1 + 13052) = 1065353216;
+        public float Unknown3300;     // offset: 13056, sz: 4, origin: 1056981385, parsed: 0.501        // line:   *(_DWORD *)(v1 + 13056) = 1056981385;
+        public float Unknown3304;     // offset: 13060, sz: 4, origin: 1048978653, parsed: 0.262        // line:   *(_DWORD *)(v1 + 13060) = 1048978653;
+        public float Unknown3308;     // offset: 13064, sz: 4, origin: 1061226021, parsed: 0.754        // line:   *(_DWORD *)(v1 + 13064) = 1061226021;
+        public float Unknown330C;     // offset: 13068, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(v1 + 13068) = 1065353216;
+        public float Unknown3310;     // offset: 13072, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(v1 + 13072) = 1065353216;
+        public float Unknown3314;     // offset: 13076, sz: 4, origin: 1046428516, parsed: 0.218        // line:   *(_DWORD *)(v1 + 13076) = 1046428516;
+        public float Unknown3318;     // offset: 13080, sz: 4, origin: 1056595509, parsed: 0.489        // line:   *(_DWORD *)(v1 + 13080) = 1056595509;
+        public float Unknown331C;     // offset: 13084, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(v1 + 13084) = 1065353216;
+        [NMS(Size = 0x100)]
+        public string Unknown3320;     // offset: 13088, sz: 256, origin:  "TEXTURES\\UI\\HUD\\POIDIAMONDFRAME.DDS"        // line:   strncpy((char *)(v1 + 13088), "TEXTURES\\UI\\HUD\\POIDIAMONDFRAME.DDS", 0x100ui64);
+        // line:   *(_BYTE *)(v1 + 13343) = 0;
+        [NMS(Size = 0x100)]
+        public string Unknown3420;     // offset: 13344, sz: 256, origin:  "TEXTURES\\UI\\HUD\\POIDIAMONDCOLOUR.DDS"        // line:   strncpy((char *)(v1 + 13344), "TEXTURES\\UI\\HUD\\POIDIAMONDCOLOUR.DDS", 0x100ui64);
+        // line:   *(_BYTE *)(v1 + 13599) = 0;
+        [NMS(Size = 0x100)]
+        public string Unknown3520;     // offset: 13600, sz: 256, origin:  "TEXTURES\\UI\\HUD\\ICONS\\PLAYER\\POINT.DDS"        // line:   strncpy((char *)(v1 + 13600), "TEXTURES\\UI\\HUD\\ICONS\\PLAYER\\POINT.DDS", 0x100ui64);
+        // line:   *(_BYTE *)(v1 + 13855) = 0;
+        [NMS(Size = 0x100)]
+        public string Unknown3620;     // offset: 13856, sz: 256, origin:  "TEXTURES\\UI\\HUD\\ICONS\\PLAYER\\SHIP.DDS"        // line:   strncpy((char *)(v1 + 13856), "TEXTURES\\UI\\HUD\\ICONS\\PLAYER\\SHIP.DDS", 0x100ui64);
+        // line:   *(_BYTE *)(v1 + 14111) = 0;
+        [NMS(Size = 0x100)]
+        public string Unknown3720;     // offset: 14112, sz: 256, origin:  "TEXTURES\\UI\\HUD\\ICONS\\PLAYER\\SAVE.DDS"        // line:   strncpy((char *)(v1 + 14112), "TEXTURES\\UI\\HUD\\ICONS\\PLAYER\\SAVE.DDS", 0x100ui64);
+        // line:   *(_BYTE *)(v1 + 14367) = 0;
+        [NMS(Size = 0x100)]
+        public string Unknown3820;     // offset: 14368, sz: 256, origin:  "TEXTURES\\UI\\HUD\\ICONS\\PLAYER\\DEATH.DDS"        // line:   strncpy((char *)(v1 + 14368), "TEXTURES\\UI\\HUD\\ICONS\\PLAYER\\DEATH.DDS", 0x100ui64);
+        // line:   *(_BYTE *)(v1 + 14623) = 0;
+        [NMS(Size = 0x100)]
+        public string Unknown3920;     // offset: 14624, sz: 256, origin:  "TEXTURES\\UI\\HUD\\ICONS\\PLAYER\\HEX.DDS"        // line:   strncpy((char *)(v1 + 14624), "TEXTURES\\UI\\HUD\\ICONS\\PLAYER\\HEX.DDS", 0x100ui64);
+        // line:   *(_BYTE *)(v1 + 14879) = 0;
+        [NMS(Size = 0x100)]
+        public string Unknown3A20;     // offset: 14880, sz: 256, origin:  "TEXTURES\\UI\\HUD\\ICONS\\PLAYER\\CIRCLE.DDS"        // line:   strncpy((char *)(v1 + 14880), "TEXTURES\\UI\\HUD\\ICONS\\PLAYER\\CIRCLE.DDS", 0x100ui64);
+        // line:   *(_BYTE *)(v1 + 15135) = 0;
+        public float Unknown3B20;     // offset: 15136, sz: 4, origin: 1058642330, parsed: 0.6        // line:   *(_DWORD *)(v1 + 15136) = 1058642330;
+        public float Unknown3B24;     // offset: 15140, sz: 4, origin: 1123024896, parsed: 120        // line:   *(_DWORD *)(v1 + 15140) = 1123024896;
+        public float Unknown3B28;     // offset: 15144, sz: 4, origin: 1038174126, parsed: 0.11        // line:   *(_DWORD *)(v1 + 15144) = 1038174126;
+        public float Unknown3B2C;     // offset: 15148, sz: 4, origin: 0x40000000i64, parsed: 2, comment: unaligned to 8 bytes! two packed floats in a QWORD?(1)
+        public float Unknown3B30;     // offset: 15152, sz: 4, origin: 0x40000000i64, parsed: 0, comment: unaligned to 8 bytes! two packed floats in a QWORD?(2)        // line:   *(_QWORD *)(v1 + 15148) = 0x40000000i64;
+        public float Unknown3B34;     // offset: 15156, sz: 4, origin: 0, parsed: 0        // line:   *(_DWORD *)(v1 + 15156) = 0;
+        public float Unknown3B38;     // offset: 15160, sz: 4, origin: 1017370378, parsed: 0.02        // line:   *(_DWORD *)(v1 + 15160) = 1017370378;
+        public float Unknown3B3C;     // offset: 15164, sz: 4, origin: 978433815, parsed: 0.0008        // line:   *(_DWORD *)(v1 + 15164) = 978433815;
+        public float Unknown3B40;     // offset: 15168, sz: 4, origin: 1024416809, parsed: 0.035        // line:   *(_DWORD *)(v1 + 15168) = 1024416809;
+        public float Unknown3B44;     // offset: 15172, sz: 4, origin: 1031127695, parsed: 0.06        // line:   *(_DWORD *)(v1 + 15172) = 1031127695;
+        public float Unknown3B48;     // offset: 15176, sz: 4, origin: 1028443341, parsed: 0.05        // line:   *(_DWORD *)(v1 + 15176) = 1028443341;
+        public float Unknown3B4C;     // offset: 15180, sz: 4, origin: 1077936128, parsed: 3        // line:   *(_DWORD *)(v1 + 15180) = 1077936128;
+        public float Unknown3B50;     // offset: 15184, sz: 4, origin: 0x40000000, parsed: 2        // line:   *(_DWORD *)(v1 + 15184) = 0x40000000;
+        public float Unknown3B54;     // offset: 15188, sz: 4, origin: 1232348160, parsed: 1000000        // line:   *(_DWORD *)(v1 + 15188) = 1232348160;
+        public float Unknown3B58;     // offset: 15192, sz: 4, origin: 1140457472, parsed: 500        // line:   *(_DWORD *)(v1 + 15192) = 1140457472;
+        public float Unknown3B5C;     // offset: 15196, sz: 4, origin: 1128792064, parsed: 200        // line:   *(_DWORD *)(v1 + 15196) = 1128792064;
+        public float Unknown3B60;     // offset: 15200, sz: 4, origin: 1203982336, parsed: 100000        // line:   *(_DWORD *)(v1 + 15200) = 1203982336;
+        public float Unknown3B64;     // offset: 15204, sz: 4, origin: 1120403456, parsed: 100        // line:   *(_DWORD *)(v1 + 15204) = 1120403456;
+        public float Unknown3B68;     // offset: 15208, sz: 4, origin: 1161527296, parsed: 3000        // line:   *(_DWORD *)(v1 + 15208) = 1161527296;
+        public float Unknown3B6C;     // offset: 15212, sz: 4, origin: 1140457472, parsed: 500        // line:   *(_DWORD *)(v1 + 15212) = 1140457472;
+        public float Unknown3B70;     // offset: 15216, sz: 4, origin: 1050253722, parsed: 0.3        // line:   *(_DWORD *)(v1 + 15216) = 1050253722;
+        public float Unknown3B74;     // offset: 15220, sz: 4, origin: 1148846080, parsed: 1000        // line:   *(_DWORD *)(v1 + 15220) = 1148846080;
+        public float Unknown3B78;     // offset: 15224, sz: 4, origin: 1128792064, parsed: 200        // line:   *(_DWORD *)(v1 + 15224) = 1128792064;
+        public float Unknown3B7C;     // offset: 15228, sz: 4, origin: 1128792064, parsed: 200        // line:   *(_DWORD *)(v1 + 15228) = 1128792064;
+        public float Unknown3B80;     // offset: 15232, sz: 4, origin: 1157234688, parsed: 2000        // line:   *(_DWORD *)(v1 + 15232) = 1157234688;
+        public float Unknown3B84;     // offset: 15236, sz: 4, origin: 1053609165i64, parsed: 0.4, comment: unaligned to 8 bytes! two packed floats in a QWORD?(1)
+        public float Unknown3B88;     // offset: 15240, sz: 4, origin: 1053609165i64, parsed: 0, comment: unaligned to 8 bytes! two packed floats in a QWORD?(2)        // line:   *(_QWORD *)(v1 + 15236) = 1053609165i64;
+        public float Unknown3B8C;     // offset: 15244, sz: 4, origin: 1092616192, parsed: 10        // line:   *(_DWORD *)(v1 + 15244) = 1092616192;
+        public float Unknown3B90;     // offset: 15248, sz: 4, origin: 1092616192, parsed: 10        // line:   *(_DWORD *)(v1 + 15248) = 1092616192;
+        public float Unknown3B94;     // offset: 15252, sz: 4, origin: 1133903872, parsed: 300        // line:   *(_DWORD *)(v1 + 15252) = 1133903872;
+        public float Unknown3B98;     // offset: 15256, sz: 4, origin: 1128792064, parsed: 200        // line:   *(_DWORD *)(v1 + 15256) = 1128792064;
+        public float Unknown3B9C;     // offset: 15260, sz: 4, origin: 1141473280, parsed: 550        // line:   *(_DWORD *)(v1 + 15260) = 1141473280;
+        public float Unknown3BA0;     // offset: 15264, sz: 4, origin: 1103101952, parsed: 24        // line:   *(_DWORD *)(v1 + 15264) = 1103101952;
+        public float Unknown3BA4;     // offset: 15268, sz: 4, origin: 1092616192, parsed: 10        // line:   *(_DWORD *)(v1 + 15268) = 1092616192;
+
+        // missing 8 bytes at offset 15268
+        // could be padding, a undefined subroutine or a pointer accessing larger memory
+        [NMS(Size = 0x8, Ignore = true)]
+        public byte[] Padding3BA8;        // offset: 15272, sz: 8, comment: auto padding 
+
+        public float Unknown3BB0;     // offset: 15280, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(v1 + 15280) = 1065353216;
+        public float Unknown3BB4;     // offset: 15284, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(v1 + 15284) = 1065353216;
+        public float Unknown3BB8;     // offset: 15288, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(v1 + 15288) = 1065353216;
+        public float Unknown3BBC;     // offset: 15292, sz: 4, origin: 1053407838, parsed: 0.394        // line:   *(_DWORD *)(v1 + 15292) = 1053407838;
+        public float Unknown3BC0;     // offset: 15296, sz: 4, origin: 1055052005, parsed: 0.443        // line:   *(_DWORD *)(v1 + 15296) = 1055052005;
+        public float Unknown3BC4;     // offset: 15300, sz: 4, origin: 1043408617, parsed: 0.173        // line:   *(_DWORD *)(v1 + 15300) = 1043408617;
+        public float Unknown3BC8;     // offset: 15304, sz: 4, origin: 1043408617, parsed: 0.173        // line:   *(_DWORD *)(v1 + 15304) = 1043408617;
+        public float Unknown3BCC;     // offset: 15308, sz: 4, origin: 1064145256, parsed: 0.928        // line:   *(_DWORD *)(v1 + 15308) = 1064145256;
+        public float Unknown3BD0;     // offset: 15312, sz: 4, origin: 1075838976, parsed: 2.5        // line:   *(_DWORD *)(v1 + 15312) = 1075838976;
+        public float Unknown3BD4;     // offset: 15316, sz: 4, origin: 1069547520, parsed: 1.5        // line:   *(_DWORD *)(v1 + 15316) = 1069547520;
+
+        // missing 8 bytes at offset 15316
+        // could be padding, a undefined subroutine or a pointer accessing larger memory
+        [NMS(Size = 0x8, Ignore = true)]
+        public byte[] Padding3BD8;        // offset: 15320, sz: 8, comment: auto padding 
+
+        public float Unknown3BE0;     // offset: 15328, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(v1 + 15328) = 1065353216;
+        public float Unknown3BE4;     // offset: 15332, sz: 4, origin: 1053072294, parsed: 0.384        // line:   *(_DWORD *)(v1 + 15332) = 1053072294;
+        public float Unknown3BE8;     // offset: 15336, sz: 4, origin: 1053072294, parsed: 0.384        // line:   *(_DWORD *)(v1 + 15336) = 1053072294;
+        public float Unknown3BEC;     // offset: 15340, sz: 4, origin: 1057434370, parsed: 0.528        // line:   *(_DWORD *)(v1 + 15340) = 1057434370;
+        public float Unknown3BF0;     // offset: 15344, sz: 4, origin: 1050253722, parsed: 0.3        // line:   *(_DWORD *)(v1 + 15344) = 1050253722;
+        public float Unknown3BF4;     // offset: 15348, sz: 4, origin: 1068708659i64, parsed: 1.4, comment: unaligned to 8 bytes! two packed floats in a QWORD?(1)
+        public float Unknown3BF8;     // offset: 15352, sz: 4, origin: 1068708659i64, parsed: 0, comment: unaligned to 8 bytes! two packed floats in a QWORD?(2)        // line:   *(_QWORD *)(v1 + 15348) = 1068708659i64;
+        public float Unknown3BFC;     // offset: 15356, sz: 4, origin: 0, parsed: 0        // line:   *(_DWORD *)(v1 + 15356) = 0;
+        public float Unknown3C00;     // offset: 15360, sz: 4, origin: 1127481344, parsed: 180        // line:   *(_DWORD *)(v1 + 15360) = 1127481344;
+        public float Unknown3C04;     // offset: 15364, sz: 4, origin: 1066192077, parsed: 1.1        // line:   *(_DWORD *)(v1 + 15364) = 1066192077;
+        public float Unknown3C08;     // offset: 15368, sz: 4, origin: 1069547520, parsed: 1.5        // line:   *(_DWORD *)(v1 + 15368) = 1069547520;
+        public float Unknown3C0C;     // offset: 15372, sz: 4, origin: 1070386381, parsed: 1.6        // line:   *(_DWORD *)(v1 + 15372) = 1070386381;
+        public float Unknown3C10;     // offset: 15376, sz: 4, origin: 1063675494, parsed: 0.9        // line:   *(_DWORD *)(v1 + 15376) = 1063675494;
+        public float Unknown3C14;     // offset: 15380, sz: 4, origin: 1068373115, parsed: 1.36        // line:   *(_DWORD *)(v1 + 15380) = 1068373115;
+        public float Unknown3C18;     // offset: 15384, sz: 4, origin: 1106247680, parsed: 30        // line:   *(_DWORD *)(v1 + 15384) = 1106247680;
+        public float Unknown3C1C;     // offset: 15388, sz: 4, origin: 1041865114, parsed: 0.15        // line:   *(_DWORD *)(v1 + 15388) = 1041865114;
+        public float Unknown3C20;     // offset: 15392, sz: 4, origin: 1092616192, parsed: 10        // line:   *(_DWORD *)(v1 + 15392) = 1092616192;
+        public float Unknown3C24;     // offset: 15396, sz: 4, origin: 1000593162, parsed: 0.005        // line:   *(_DWORD *)(v1 + 15396) = 1000593162;
+
+        // missing 8 bytes at offset 15396
+        // could be padding, a undefined subroutine or a pointer accessing larger memory
+        [NMS(Size = 0x8, Ignore = true)]
+        public byte[] Padding3C28;        // offset: 15400, sz: 8, comment: auto padding 
+
+        public float Unknown3C30;     // offset: 15408, sz: 4, origin: -1105618534, parsed: -0.15        // line:   *(_DWORD *)(v1 + 15408) = -1105618534;
+        public float Unknown3C34;     // offset: 15412, sz: 4, origin: -1123066839, parsed: -0.035        // line:   *(_DWORD *)(v1 + 15412) = -1123066839;
+        public float Unknown3C38;     // offset: 15416, sz: 4, origin: 0, parsed: 0        // line:   *(_DWORD *)(v1 + 15416) = 0;
+
+        // missing 4 bytes at offset 15416
+        // could be padding, a undefined subroutine or a pointer accessing larger memory
+        [NMS(Size = 0x4, Ignore = true)]
+        public byte[] Padding3C3C;        // offset: 15420, sz: 4, comment: auto padding 
+
+        public float Unknown3C40;     // offset: 15424, sz: 4, origin: -1105618534, parsed: -0.15        // line:   *(_DWORD *)(v1 + 15424) = -1105618534;
+        public float Unknown3C44;     // offset: 15428, sz: 4, origin: -1123066839, parsed: -0.035        // line:   *(_DWORD *)(v1 + 15428) = -1123066839;
+        public float Unknown3C48;     // offset: 15432, sz: 4, origin: 0, parsed: 0        // line:   *(_DWORD *)(v1 + 15432) = 0;
+
+        // missing 4 bytes at offset 15432
+        // could be padding, a undefined subroutine or a pointer accessing larger memory
+        [NMS(Size = 0x4, Ignore = true)]
+        public byte[] Padding3C4C;        // offset: 15436, sz: 4, comment: auto padding 
+
+        public float Unknown3C50;     // offset: 15440, sz: 4, origin: 1025758986, parsed: 0.04        // line:   *(_DWORD *)(v1 + 15440) = 1025758986;
+        public float Unknown3C54;     // offset: 15444, sz: 4, origin: -1133133169, parsed: -0.015        // line:   *(_DWORD *)(v1 + 15444) = -1133133169;
+        public float Unknown3C58;     // offset: 15448, sz: 4, origin: 0, parsed: 0        // line:   *(_DWORD *)(v1 + 15448) = 0;
+
+        // missing 4 bytes at offset 15448
+        // could be padding, a undefined subroutine or a pointer accessing larger memory
+        [NMS(Size = 0x4, Ignore = true)]
+        public byte[] Padding3C5C;        // offset: 15452, sz: 4, comment: auto padding 
+
+        public float Unknown3C60;     // offset: 15456, sz: 4, origin: -1029701632, parsed: -80        // line:   *(_DWORD *)(v1 + 15456) = -1029701632;
+        public float Unknown3C64;     // offset: 15460, sz: 4, origin: 1066192077, parsed: 1.1        // line:   *(_DWORD *)(v1 + 15460) = 1066192077;
+        public float Unknown3C68;     // offset: 15464, sz: 4, origin: 1077936128, parsed: 3        // line:   *(_DWORD *)(v1 + 15464) = 1077936128;
+        public float Unknown3C6C;     // offset: 15468, sz: 4, origin: 1050253722, parsed: 0.3        // line:   *(_DWORD *)(v1 + 15468) = 1050253722;
+        public float Unknown3C70;     // offset: 15472, sz: 4, origin: 1139802112, parsed: 480        // line:   *(_DWORD *)(v1 + 15472) = 1139802112;
+        public float Unknown3C74;     // offset: 15476, sz: 4, origin: 1132920832, parsed: 270        // line:   *(_DWORD *)(v1 + 15476) = 1132920832;
+        public float Unknown3C78;     // offset: 15480, sz: 4, origin: 1139802112, parsed: 480        // line:   *(_DWORD *)(v1 + 15480) = 1139802112;
+        public float Unknown3C7C;     // offset: 15484, sz: 4, origin: 1132920832, parsed: 270        // line:   *(_DWORD *)(v1 + 15484) = 1132920832;
+        public float Unknown3C80;     // offset: 15488, sz: 4, origin: 1059014784, parsed: 0.6222        // line:   *(_DWORD *)(v1 + 15488) = 1059014784;
+        public float Unknown3C84;     // offset: 15492, sz: 4, origin: 1051931443, parsed: 0.35        // line:   *(_DWORD *)(v1 + 15492) = 1051931443;
+        public float Unknown3C88;     // offset: 15496, sz: 4, origin: 1031664566, parsed: 0.062        // line:   *(_DWORD *)(v1 + 15496) = 1031664566;
+        public float Unknown3C8C;     // offset: 15500, sz: 4, origin: 1024416809, parsed: 0.035        // line:   *(_DWORD *)(v1 + 15500) = 1024416809;
+        public float Unknown3C90;     // offset: 15504, sz: 4, origin: 1039516303, parsed: 0.12        // line:   *(_DWORD *)(v1 + 15504) = 1039516303;
+        public float Unknown3C94;     // offset: 15508, sz: 4, origin: 1039516303, parsed: 0.12        // line:   *(_DWORD *)(v1 + 15508) = 1039516303;
+        public float Unknown3C98;     // offset: 15512, sz: 4, origin: 1028443341, parsed: 0.05        // line:   *(_DWORD *)(v1 + 15512) = 1028443341;
+        public float Unknown3C9C;     // offset: 15516, sz: 4, origin: 1050253722i64, parsed: 0.3, comment: unaligned to 8 bytes! two packed floats in a QWORD?(1)
+        public float Unknown3CA0;     // offset: 15520, sz: 4, origin: 1050253722i64, parsed: 0, comment: unaligned to 8 bytes! two packed floats in a QWORD?(2)        // line:   *(_QWORD *)(v1 + 15516) = 1050253722i64;
+        public bool Unknown3CA4;     // offset: 15524, sz: 1, origin: 1, parsed: 1        // line:   *(_BYTE *)(v1 + 15524) = 1;
+
+        // missing 3 bytes at offset 15524
+        // does 15524 contain a DWORD?
+        [NMS(Size = 0x3, Ignore = true)]
+        public byte[] Padding3CA5;        // offset: 15525, sz: 3, comment: auto padding 
+
+        public float Unknown3CA8;     // offset: 15528, sz: 4, origin: 1092616192, parsed: 10        // line:   *(_DWORD *)(v1 + 15528) = 1092616192;
+        public float Unknown3CAC;     // offset: 15532, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(v1 + 15532) = 1065353216;
+        public float Unknown3CB0;     // offset: 15536, sz: 4, origin: 1088421888, parsed: 7        // line:   *(_DWORD *)(v1 + 15536) = 1088421888;
+        // line:   result = v1 + 15564;
+        // line: //  v3 = 13i64;
+        public float Unknown3CB4;     // offset: 15540, sz: 4, origin: 0x40000000, parsed: 2        // line:   *(_DWORD *)(v1 + 15540) = 0x40000000;
+        public float Unknown3CB8;     // offset: 15544, sz: 4, origin: 1097859072, parsed: 15        // line:   *(_DWORD *)(v1 + 15544) = 1097859072;
+        public float Unknown3CBC;     // offset: 15548, sz: 4, origin: 0x40000000, parsed: 2        // line:   *(_DWORD *)(v1 + 15548) = 0x40000000;
+        public float Unknown3CC0;     // offset: 15552, sz: 4, origin: 1036831949, parsed: 0.1        // line:   *(_DWORD *)(v1 + 15552) = 1036831949;
+        public float Unknown3CC4;     // offset: 15556, sz: 4, origin: 1045220557, parsed: 0.2        // line:   *(_DWORD *)(v1 + 15556) = 1045220557;
+        public float Unknown3CC8;     // offset: 15560, sz: 4, origin: 1063675494, parsed: 0.9        // line:   *(_DWORD *)(v1 + 15560) = 1063675494;
+        // line: //  do
+        // line: //  {
+        // line: //    *(_DWORD *)result = 0;
+        // line: //    *(_DWORD *)(result + 4) = 1065353216;
+        // line: //    result += 8i64;
+        // line: //    --v3;
+        // line: //  }
+        // line: //  while ( v3 );
+        // line: //
+        // line: // start unrolled do/while loop (manual)
+        // line: //
+        public float Unknown3CCC;     // offset: 15564, sz: 4, origin: 0, parsed: 0        // line:   *(_DWORD *)(v1 + 15564) = 0; // 13
+        public float Unknown3CD0;     // offset: 15568, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(v1 + 15568) = 1065353216;
+        public float Unknown3CD4;     // offset: 15572, sz: 4, origin: 0, parsed: 0        // line:   *(_DWORD *)(v1 + 15572) = 0; // 12
+        public float Unknown3CD8;     // offset: 15576, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(v1 + 15576) = 1065353216;
+        public float Unknown3CDC;     // offset: 15580, sz: 4, origin: 0, parsed: 0        // line:   *(_DWORD *)(v1 + 15580) = 0; // 11
+        public float Unknown3CE0;     // offset: 15584, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(v1 + 15584) = 1065353216;
+        public float Unknown3CE4;     // offset: 15588, sz: 4, origin: 0, parsed: 0        // line:   *(_DWORD *)(v1 + 15588) = 0; // 10
+        public float Unknown3CE8;     // offset: 15592, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(v1 + 15592) = 1065353216;
+        public float Unknown3CEC;     // offset: 15596, sz: 4, origin: 0, parsed: 0        // line:   *(_DWORD *)(v1 + 15596) = 0; // 9
+        public float Unknown3CF0;     // offset: 15600, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(v1 + 15600) = 1065353216;
+        public float Unknown3CF4;     // offset: 15604, sz: 4, origin: 0, parsed: 0        // line:   *(_DWORD *)(v1 + 15604) = 0; // 8
+        public float Unknown3CF8;     // offset: 15608, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(v1 + 15608) = 1065353216;
+        public float Unknown3CFC;     // offset: 15612, sz: 4, origin: 0, parsed: 0        // line:   *(_DWORD *)(v1 + 15612) = 0; // 7
+        public float Unknown3D00;     // offset: 15616, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(v1 + 15616) = 1065353216;
+        public float Unknown3D04;     // offset: 15620, sz: 4, origin: 0, parsed: 0        // line:   *(_DWORD *)(v1 + 15620) = 0; // 6
+        public float Unknown3D08;     // offset: 15624, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(v1 + 15624) = 1065353216;
+        public float Unknown3D0C;     // offset: 15628, sz: 4, origin: 0, parsed: 0        // line:   *(_DWORD *)(v1 + 15628) = 0; // 5
+        public float Unknown3D10;     // offset: 15632, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(v1 + 15632) = 1065353216;
+        public float Unknown3D14;     // offset: 15636, sz: 4, origin: 0, parsed: 0        // line:   *(_DWORD *)(v1 + 15636) = 0; // 4
+        public float Unknown3D18;     // offset: 15640, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(v1 + 15640) = 1065353216;
+        public float Unknown3D1C;     // offset: 15644, sz: 4, origin: 0, parsed: 0        // line:   *(_DWORD *)(v1 + 15644) = 0; // 3
+        public float Unknown3D20;     // offset: 15648, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(v1 + 15648) = 1065353216;
+        public float Unknown3D24;     // offset: 15652, sz: 4, origin: 0, parsed: 0        // line:   *(_DWORD *)(v1 + 15652) = 0; // 2
+        public float Unknown3D28;     // offset: 15656, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(v1 + 15656) = 1065353216;
+        public float Unknown3D2C;     // offset: 15660, sz: 4, origin: 0, parsed: 0        // line:   *(_DWORD *)(v1 + 15660) = 0; // 1
+        public float Unknown3D30;     // offset: 15664, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(v1 + 15664) = 1065353216;
+        // line: //
+        // line: // end unrolled do/while loop
+        // line: // NOTE: bellow some assignments are manually re-ordered so that the offsets are ascending
+        public bool Unknown3D34;     // offset: 15668, sz: 1, origin: 0, parsed: 0        // line:   *(_BYTE *)(v1 + 15668) = 0;
+
+        // missing 3 bytes at offset 15668
+        // does 15668 contain a DWORD?
+        [NMS(Size = 0x3, Ignore = true)]
+        public byte[] Padding3D35;        // offset: 15669, sz: 3, comment: auto padding 
+
+        public float Unknown3D38;     // offset: 15672, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(v1 + 15672) = 1065353216;
+        public float Unknown3D3C;     // offset: 15676, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(v1 + 15676) = 1065353216;
+        public float Unknown3D40;     // offset: 15680, sz: 4, origin: 0x40000000i64, parsed: 2, comment: unaligned to 8 bytes! two packed floats in a QWORD?(1)
+        public float Unknown3D44;     // offset: 15684, sz: 4, origin: 0x40000000i64, parsed: 0, comment: unaligned to 8 bytes! two packed floats in a QWORD?(2)        // line:   *(_QWORD *)(v1 + 15680) = 0x40000000i64;
+        public long Unknown3D48;     // offset: 15688, sz: 8, origin: 0i64, parsed: 0. comment: aligned to 8 bytes! a long. two floats or two ints?        // line:   *(_QWORD *)(v1 + 15688) = 0i64;
+        public bool Unknown3D50;     // offset: 15696, sz: 1, origin: 0, parsed: 0        // line:   *(_BYTE *)(v1 + 15696) = 0;
+
+        // missing 3 bytes at offset 15696
+        // does 15696 contain a DWORD?
+        [NMS(Size = 0x3, Ignore = true)]
+        public byte[] Padding3D51;        // offset: 15697, sz: 3, comment: auto padding 
+
+        public float Unknown3D54;     // offset: 15700, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(v1 + 15700) = 1065353216;
+        public float Unknown3D58;     // offset: 15704, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(v1 + 15704) = 1065353216;
+        public float Unknown3D5C;     // offset: 15708, sz: 4, origin: 0x40000000i64, parsed: 2, comment: unaligned to 8 bytes! two packed floats in a QWORD?(1)
+        public float Unknown3D60;     // offset: 15712, sz: 4, origin: 0x40000000i64, parsed: 0, comment: unaligned to 8 bytes! two packed floats in a QWORD?(2)        // line:   *(_QWORD *)(v1 + 15708) = 0x40000000i64;
+        public float Unknown3D64;     // offset: 15716, sz: 4, origin: 0i64, parsed: 0, comment: unaligned to 8 bytes! two packed floats in a QWORD?(1)
+        public float Unknown3D68;     // offset: 15720, sz: 4, origin: 0i64, parsed: 0, comment: unaligned to 8 bytes! two packed floats in a QWORD?(2)        // line:   *(_QWORD *)(v1 + 15716) = 0i64;
+        public bool Unknown3D6C;     // offset: 15724, sz: 1, origin: 0, parsed: 0        // line:   *(_BYTE *)(v1 + 15724) = 0;
+
+        // missing 3 bytes at offset 15724
+        // does 15724 contain a DWORD?
+        [NMS(Size = 0x3, Ignore = true)]
+        public byte[] Padding3D6D;        // offset: 15725, sz: 3, comment: auto padding 
+
+        public float Unknown3D70;     // offset: 15728, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(v1 + 15728) = 1065353216;
+        public float Unknown3D74;     // offset: 15732, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(v1 + 15732) = 1065353216;
+        public float Unknown3D78;     // offset: 15736, sz: 4, origin: 0x40000000i64, parsed: 2, comment: unaligned to 8 bytes! two packed floats in a QWORD?(1)
+        public float Unknown3D7C;     // offset: 15740, sz: 4, origin: 0x40000000i64, parsed: 0, comment: unaligned to 8 bytes! two packed floats in a QWORD?(2)        // line:   *(_QWORD *)(v1 + 15736) = 0x40000000i64;
+        public long Unknown3D80;     // offset: 15744, sz: 8, origin: 0i64, parsed: 0. comment: aligned to 8 bytes! a long. two floats or two ints?        // line:   *(_QWORD *)(v1 + 15744) = 0i64;
+        public bool Unknown3D88;     // offset: 15752, sz: 1, origin: 0, parsed: 0        // line:   *(_BYTE *)(v1 + 15752) = 0;
+
+        // missing 3 bytes at offset 15752
+        // does 15752 contain a DWORD?
+        [NMS(Size = 0x3, Ignore = true)]
+        public byte[] Padding3D89;        // offset: 15753, sz: 3, comment: auto padding 
+
+        public float Unknown3D8C;     // offset: 15756, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(v1 + 15756) = 1065353216;
+        public float Unknown3D90;     // offset: 15760, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(v1 + 15760) = 1065353216;
+        public float Unknown3D94;     // offset: 15764, sz: 4, origin: 0x40000000i64, parsed: 2, comment: unaligned to 8 bytes! two packed floats in a QWORD?(1)
+        public float Unknown3D98;     // offset: 15768, sz: 4, origin: 0x40000000i64, parsed: 0, comment: unaligned to 8 bytes! two packed floats in a QWORD?(2)        // line:   *(_QWORD *)(v1 + 15764) = 0x40000000i64;
+        public float Unknown3D9C;     // offset: 15772, sz: 4, origin: 0i64, parsed: 0, comment: unaligned to 8 bytes! two packed floats in a QWORD?(1)
+        public float Unknown3DA0;     // offset: 15776, sz: 4, origin: 0i64, parsed: 0, comment: unaligned to 8 bytes! two packed floats in a QWORD?(2)        // line:   *(_QWORD *)(v1 + 15772) = 0i64;
+        public bool Unknown3DA4;     // offset: 15780, sz: 1, origin: 0, parsed: 0        // line:   *(_BYTE *)(v1 + 15780) = 0;
+
+        // missing 3 bytes at offset 15780
+        // does 15780 contain a DWORD?
+        [NMS(Size = 0x3, Ignore = true)]
+        public byte[] Padding3DA5;        // offset: 15781, sz: 3, comment: auto padding 
+
+        public float Unknown3DA8;     // offset: 15784, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(v1 + 15784) = 1065353216;
+        public float Unknown3DAC;     // offset: 15788, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(v1 + 15788) = 1065353216;
+        public float Unknown3DB0;     // offset: 15792, sz: 4, origin: 0x40000000i64, parsed: 2, comment: unaligned to 8 bytes! two packed floats in a QWORD?(1)
+        public float Unknown3DB4;     // offset: 15796, sz: 4, origin: 0x40000000i64, parsed: 0, comment: unaligned to 8 bytes! two packed floats in a QWORD?(2)        // line:   *(_QWORD *)(v1 + 15792) = 0x40000000i64;
+        public long Unknown3DB8;     // offset: 15800, sz: 8, origin: 0i64, parsed: 0. comment: aligned to 8 bytes! a long. two floats or two ints?        // line:   *(_QWORD *)(v1 + 15800) = 0i64;
+        public bool Unknown3DC0;     // offset: 15808, sz: 1, origin: 0, parsed: 0        // line:   *(_BYTE *)(v1 + 15808) = 0;
+
+        // missing 3 bytes at offset 15808
+        // does 15808 contain a DWORD?
+        [NMS(Size = 0x3, Ignore = true)]
+        public byte[] Padding3DC1;        // offset: 15809, sz: 3, comment: auto padding 
+
+        public float Unknown3DC4;     // offset: 15812, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(v1 + 15812) = 1065353216;
+        public float Unknown3DC8;     // offset: 15816, sz: 4, origin: 1065353216, parsed: 1        // line:   *(_DWORD *)(v1 + 15816) = 1065353216;
+        public float Unknown3DCC;     // offset: 15820, sz: 4, origin: 0x40000000i64, parsed: 2, comment: unaligned to 8 bytes! two packed floats in a QWORD?(1)
+        public float Unknown3DD0;     // offset: 15824, sz: 4, origin: 0x40000000i64, parsed: 0, comment: unaligned to 8 bytes! two packed floats in a QWORD?(2)        // line:   *(_QWORD *)(v1 + 15820) = 0x40000000i64;
+        public float Unknown3DD4;     // offset: 15828, sz: 4, origin: 0i64, parsed: 0, comment: unaligned to 8 bytes! two packed floats in a QWORD?(1)
+        public float Unknown3DD8;     // offset: 15832, sz: 4, origin: 0i64, parsed: 0, comment: unaligned to 8 bytes! two packed floats in a QWORD?(2)        // line:   *(_QWORD *)(v1 + 15828) = 0i64;
+        // line:   return result;
+        // line: }
+
+        [NMS(Size = 0x4, Ignore = true)]
+        public byte[] Padding3DDC;        // offset: 15836, sz: 4, comment: auto-padding at the end
+
+        // accumulated template size: 15840 (0x3DE0)
+        // number of properties parsed: 726
+    }
+}


### PR DESCRIPTION
hello @emoose ,

need some help here as GcUIGlobals fails the size test. once this is fixed i can rebase the PR.

the new version of the parser now supports accumulating the size of parsed properties via a toggle (define_log_acc_size). it adds "acc. size: <newsz>" to each line and also shows the total size in the end (now with even more comments in the output...will delete them once fixed).

as far as i can tell and in the case of GcUIGlobals it accumulates the correct size of 15836 and then the parser adds 4 bytes of padding in the end to make it 15840 (0x3DE0).

but the class then fails the size test by being 28 bytes larger:

```
Result Message:	Assert.AreEqual failed. Expected:<15840>. Actual:<15868>. template GcUIGlobals size 0x3DFC != 0x3DE0
```

there is nothing special about the GcUIGlobals template contents except one GcModelViewCollection property a do/while loop unroll and one string which is null terminated one byte earlier (leaving one byte of padding).

i've checked this multiple times for mistakes, to no avail. GcModelViewCollection which is a child of GcUIGlobals passes the size test and all the padding and string sizes in the class seem OK.

any idea what i could be missing?
